### PR TITLE
Add netlify-plugin-ghost-markdown to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **10** 🎉
+Plugin count: **11** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
@@ -21,6 +21,7 @@ Plugin count: **10** 🎉
 | **[Deployment Hours - `netlify-deployment-hours-plugin`](https://github.com/neverendingqs/netlify-deployment-hours-plugin)** <br/>  A Netlify build plugin that blocks deployment if it outside of deployment hours. | [neverendingqs](https://github.com/neverendingqs) |
 | **[Fetch Feeds - `netlify-plugin-fetch-feeds`](https://github.com/philhawksworth/netlify-plugin-fetch-feeds)** <br/>  A Netlify plugin to source content from remote feeds including RSS and JSON | [philhawksworth](https://github.com/philhawksworth) |
 | **[Gatsby Cache - `netlify-plugin-gatsby-cache`](https://github.com/jlengstorf/netlify-plugin-gatsby-cache#readme)** <br/>  Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️ | [jlengstorf](https://github.com/jlengstorf) |
+| **[Ghost Markdown - `netlify-plugin-ghost-markdown`](https://github.com/daviddarnes/netlify-plugin-ghost-markdown)** <br/>  Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API. | [daviddarnes](https://github.com/daviddarnes) |
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
 | **[Image Optim - `netlify-plugin-image-optim`](https://github.com/chrisdwheatley/netlify-plugin-image-optim)** <br/>  Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats. | [chrisdwheatley](https://github.com/chrisdwheatley) |
 | **[Subfont - `netlify-plugin-subfont`](https://github.com/munter/netlify-plugin-subfont)** <br/>  Subfont post-processes your web page to analyse you usage of web fonts, then reworks your webpage to use an optimal font loading strategy for the best performance. | [munter](https://github.com/munter) |

--- a/plugins.json
+++ b/plugins.json
@@ -1,8 +1,8 @@
 [
   {
-  "name": "netlify-build-plugin-speedcurve",
-  "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
-  "repo": "https://github.com/tkadlec/netlify-build-plugin-speedcurve"
+    "name": "netlify-build-plugin-speedcurve",
+    "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
+    "repo": "https://github.com/tkadlec/netlify-build-plugin-speedcurve"
   },
   {
     "name": "netlify-plugin-checklinks",
@@ -48,5 +48,10 @@
     "name": "@netlify/plugin-sitemap",
     "description": "Automatically generate a sitemap for your site on PostBuild in Netlify",
     "repo": "https://github.com/netlify-labs/netlify-plugin-sitemap"
+  },
+  {
+    "name": "netlify-plugin-ghost-markdown",
+    "description": "Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API.",
+    "repo": "https://github.com/daviddarnes/netlify-plugin-ghost-markdown"
   }
 ]


### PR DESCRIPTION
👋 Recently been experimenting with build plugins after an idea popped into my head. Some SSGs only deal with files, which makes it hard to integrate with the Ghost Content API. 

So what if there could be a build plugin that generated the files from the API before the build began? This plugin does exactly that! Mainly for Jekyll users, but the configuration options allow for other SSGs too.

Thanks for inviting me to the beta, and for all the Netlify stuff you do ✌️