### PR TITLE
Add author and name per plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Plugin count: **13** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
-| **[Sitemap plugin - `@netlify/plugin-sitemap`](https://github.com/netlify-labs/netlify-plugin-sitemap)** <br/>  Automatically generate a sitemap for your site on PostBuild in Netlify | [netlify-labs](https://github.com/netlify-labs) |
 | **[Build Plugin Speedcurve - `netlify-build-plugin-speedcurve`](https://github.com/tkadlec/netlify-build-plugin-speedcurve)** <br/>  After a successful build, tell SpeedCurve you've deployed and trigger a round of testing | [tkadlec](https://github.com/tkadlec) |
 | **[Cache Nextjs - `netlify-plugin-cache-nextjs`](https://github.com/pizzafox/netlify-cache-nextjs#readme)** <br/>  Cache the .next folder in Netlify builds | [pizzafox](https://github.com/pizzafox) |
 | **[Checklinks - `netlify-plugin-checklinks`](https://github.com/munter/netlify-plugin-checklinks)** <br/>  Checklinks helps you keep all your asset references correct and avoid embarrassing broken links to your internal pages, or even to external pages you link out to. | [munter](https://github.com/munter) |
@@ -26,6 +25,7 @@ Plugin count: **13** 🎉
 | **[Ghost Markdown - `netlify-plugin-ghost-markdown`](https://github.com/daviddarnes/netlify-plugin-ghost-markdown)** <br/>  Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API. | [daviddarnes](https://github.com/daviddarnes) |
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
 | **[Image Optim - `netlify-plugin-image-optim`](https://github.com/chrisdwheatley/netlify-plugin-image-optim)** <br/>  Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats. | [chrisdwheatley](https://github.com/chrisdwheatley) |
+| **[Sitemap plugin - `@netlify/plugin-sitemap`](https://github.com/netlify-labs/netlify-plugin-sitemap)** <br/>  Automatically generate a sitemap for your site on PostBuild in Netlify | [netlify-labs](https://github.com/netlify-labs) |
 | **[Subfont - `netlify-plugin-subfont`](https://github.com/munter/netlify-plugin-subfont)** <br/>  Subfont post-processes your web page to analyse you usage of web fonts, then reworks your webpage to use an optimal font loading strategy for the best performance. | [munter](https://github.com/munter) |
 | **[Yield Data For Eleventy - `netlify-plugin-yield-data-for-eleventy`](https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy)** <br/>  A Netlify plugin to expose data collected to in the Netlify build cache to place and structure that Eleventy can use | [philhawksworth](https://github.com/philhawksworth) |
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **12** 🎉
+Plugin count: **13** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
 | **[Sitemap plugin - `@netlify/plugin-sitemap`](https://github.com/netlify-labs/netlify-plugin-sitemap)** <br/>  Automatically generate a sitemap for your site on PostBuild in Netlify | [netlify-labs](https://github.com/netlify-labs) |
 | **[Build Plugin Speedcurve - `netlify-build-plugin-speedcurve`](https://github.com/tkadlec/netlify-build-plugin-speedcurve)** <br/>  After a successful build, tell SpeedCurve you've deployed and trigger a round of testing | [tkadlec](https://github.com/tkadlec) |
+| **[Cache Nextjs - `netlify-plugin-cache-nextjs`](https://github.com/pizzafox/netlify-cache-nextjs#readme)** <br/>  Cache the .next folder in Netlify builds | [pizzafox](https://github.com/pizzafox) |
 | **[Checklinks - `netlify-plugin-checklinks`](https://github.com/munter/netlify-plugin-checklinks)** <br/>  Checklinks helps you keep all your asset references correct and avoid embarrassing broken links to your internal pages, or even to external pages you link out to. | [munter](https://github.com/munter) |
 | **[Debug Cache - `netlify-plugin-debug-cache`](https://github.com/netlify-labs/netlify-plugin-debug-cache)** <br/>  Debug & verify the contents of your Netlify build cache | [netlify-labs](https://github.com/netlify-labs) |
 | **[Deployment Hours - `netlify-deployment-hours-plugin`](https://github.com/neverendingqs/netlify-deployment-hours-plugin)** <br/>  A Netlify build plugin that blocks deployment if it outside of deployment hours. | [neverendingqs](https://github.com/neverendingqs) |

--- a/plugins.json
+++ b/plugins.json
@@ -1,80 +1,93 @@
 [
   {
     "author": "tkadlec",
-    "name": "netlify-build-plugin-speedcurve",
     "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
+    "name": "Build Plugin Speedcurve",
+    "package": "netlify-build-plugin-speedcurve",
     "repo": "https://github.com/tkadlec/netlify-build-plugin-speedcurve"
   },
   {
     "author": "munter",
-    "name": "netlify-plugin-checklinks",
     "description": "Checklinks helps you keep all your asset references correct and avoid embarrassing broken links to your internal pages, or even to external pages you link out to.",
+    "name": "Checklinks",
+    "package": "netlify-plugin-checklinks",
     "repo": "https://github.com/munter/netlify-plugin-checklinks"
   },
   {
     "author": "munter",
-    "name": "netlify-plugin-subfont",
     "description": "Subfont post-processes your web page to analyse you usage of web fonts, then reworks your webpage to use an optimal font loading strategy for the best performance.",
+    "name": "Subfont",
+    "package": "netlify-plugin-subfont",
     "repo": "https://github.com/munter/netlify-plugin-subfont"
   },
   {
     "author": "munter",
-    "name": "netlify-plugin-hashfiles",
     "description": "Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested.",
+    "name": "Hashfiles",
+    "package": "netlify-plugin-hashfiles",
     "repo": "https://github.com/munter/netlify-plugin-hashfiles"
   },
   {
     "author": "neverendingqs",
-    "name": "netlify-deployment-hours-plugin",
     "description": "A Netlify build plugin that blocks deployment if it outside of deployment hours.",
+    "name": "Deployment Hours",
+    "package": "netlify-deployment-hours-plugin",
     "repo": "https://github.com/neverendingqs/netlify-deployment-hours-plugin"
   },
   {
     "author": "philhawksworth",
-    "name": "netlify-plugin-fetch-feeds",
     "description": "A Netlify plugin to source content from remote feeds including RSS and JSON",
+    "name": "Fetch Feeds",
+    "package": "netlify-plugin-fetch-feeds",
     "repo": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds"
   },
   {
     "author": "philhawksworth",
-    "name": "netlify-plugin-yield-data-for-eleventy",
     "description": "A Netlify plugin to expose data collected to in the Netlify build cache to place and structure that Eleventy can use",
+    "name": "Yield Data For Eleventy",
+    "package": "netlify-plugin-yield-data-for-eleventy",
     "repo": "https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy"
   },
   {
     "author": "chrisdwheatley",
-    "name": "netlify-plugin-image-optim",
     "description": "Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats.",
+    "name": "Image Optim",
+    "package": "netlify-plugin-image-optim",
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim"
   },
   {
     "author": "jlengstorf",
-    "name": "netlify-plugin-gatsby-cache",
     "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️",
+    "name": "Gatsby Cache",
+    "package": "netlify-plugin-gatsby-cache",
     "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache#readme"
   },
   {
     "author": "pizzafox",
-    "name": "netlify-plugin-cache-nextjs",
     "description": "Cache the .next folder in Netlify builds",
+    "name": "Cache Nextjs",
+    "package": "netlify-plugin-cache-nextjs",
     "repo": "https://github.com/pizzafox/netlify-cache-nextjs#readme"
   },
   {
     "author": "netlify-labs",
-    "name": "@netlify/plugin-sitemap",
     "description": "Automatically generate a sitemap for your site on PostBuild in Netlify",
+    "name": "Sitemap plugin",
+    "package": "@netlify/plugin-sitemap",
     "repo": "https://github.com/netlify-labs/netlify-plugin-sitemap"
   },
   {
     "author": "daviddarnes",
-    "name": "netlify-plugin-ghost-markdown",
     "description": "Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API.",
+    "name": "Ghost Markdown",
+    "package": "netlify-plugin-ghost-markdown",
     "repo": "https://github.com/daviddarnes/netlify-plugin-ghost-markdown"
   },
   {
     "author": "netlify-labs",
-    "name": "netlify-plugin-debug-cache",
     "description": "Debug & verify the contents of your Netlify build cache",
+    "name": "Debug Cache",
+    "package": "netlify-plugin-debug-cache",
     "repo": "https://github.com/netlify-labs/netlify-plugin-debug-cache"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -1,65 +1,78 @@
 [
   {
+    "author": "tkadlec",
     "name": "netlify-build-plugin-speedcurve",
     "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
     "repo": "https://github.com/tkadlec/netlify-build-plugin-speedcurve"
   },
   {
+    "author": "munter",
     "name": "netlify-plugin-checklinks",
     "description": "Checklinks helps you keep all your asset references correct and avoid embarrassing broken links to your internal pages, or even to external pages you link out to.",
     "repo": "https://github.com/munter/netlify-plugin-checklinks"
   },
   {
+    "author": "munter",
     "name": "netlify-plugin-subfont",
     "description": "Subfont post-processes your web page to analyse you usage of web fonts, then reworks your webpage to use an optimal font loading strategy for the best performance.",
     "repo": "https://github.com/munter/netlify-plugin-subfont"
   },
   {
+    "author": "munter",
     "name": "netlify-plugin-hashfiles",
     "description": "Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested.",
     "repo": "https://github.com/munter/netlify-plugin-hashfiles"
   },
   {
+    "author": "neverendingqs",
     "name": "netlify-deployment-hours-plugin",
     "description": "A Netlify build plugin that blocks deployment if it outside of deployment hours.",
     "repo": "https://github.com/neverendingqs/netlify-deployment-hours-plugin"
   },
   {
+    "author": "philhawksworth",
     "name": "netlify-plugin-fetch-feeds",
     "description": "A Netlify plugin to source content from remote feeds including RSS and JSON",
     "repo": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds"
   },
   {
+    "author": "philhawksworth",
     "name": "netlify-plugin-yield-data-for-eleventy",
     "description": "A Netlify plugin to expose data collected to in the Netlify build cache to place and structure that Eleventy can use",
     "repo": "https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy"
   },
   {
+    "author": "chrisdwheatley",
     "name": "netlify-plugin-image-optim",
     "description": "Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats.",
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim"
   },
   {
+    "author": "jlengstorf",
     "name": "netlify-plugin-gatsby-cache",
     "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️",
     "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache#readme"
   },
   {
+    "author": "pizzafox",
     "name": "netlify-plugin-cache-nextjs",
     "description": "Cache the .next folder in Netlify builds",
     "repo": "https://github.com/pizzafox/netlify-cache-nextjs#readme"
   },
   {
+    "author": "netlify-labs",
     "name": "@netlify/plugin-sitemap",
     "description": "Automatically generate a sitemap for your site on PostBuild in Netlify",
     "repo": "https://github.com/netlify-labs/netlify-plugin-sitemap"
   },
   {
+    "author": "daviddarnes",
     "name": "netlify-plugin-ghost-markdown",
     "description": "Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API.",
     "repo": "https://github.com/daviddarnes/netlify-plugin-ghost-markdown"
   },
   {
+    "author": "netlify-labs",
     "name": "netlify-plugin-debug-cache",
     "description": "Debug & verify the contents of your Netlify build cache",
     "repo": "https://github.com/netlify-labs/netlify-plugin-debug-cache"

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,5 +1,4 @@
 const fs = require('fs')
-const url = require('url')
 const path = require('path')
 const markdownMagic = require('markdown-magic')
 
@@ -19,7 +18,7 @@ const mdConfig = {
     GENERATE_PLUGIN_LIST: function(content, options) {
       let md = ''
       PLUGINS.sort(sortPlugins).forEach((data) => {
-        md += `- **[${formatPluginName(data.name)} - \`${data.name.toLowerCase()}\`](${data.repo})** ${data.description}\n`
+        md += `- **[${data.name} - \`${data.package.toLowerCase()}\`](${data.repo})** ${data.description}\n`
       })
       return md.replace(/^\s+|\s+$/g, '')
     },
@@ -33,11 +32,10 @@ const mdConfig = {
       md += `| Plugin | Author |\n`
       md += '|:---------------------------|:-----------:|\n'
       PLUGINS.sort(sortPlugins).forEach((data) => {
-        const userName = data.author;
-        const profileURL = `https://github.com/${userName}`
-        md += `| **[${formatPluginName(data.name)} - \`${data.name.toLowerCase()}\`](${data.repo})** <br/> `
+        const profileURL = `https://github.com/${data.author}`
+        md += `| **[${data.name} - \`${data.package.toLowerCase()}\`](${data.repo})** <br/> `
         md += ` ${data.description} | `
-        md += `[${userName}](${profileURL}) |\n`
+        md += `[${data.author}](${profileURL}) |\n`
       })
       return md.replace(/^\s+|\s+$/g, '')
     }
@@ -49,26 +47,6 @@ function sortPlugins(a, b) {
   const aName = a.name.toLowerCase()
   const bName = b.name.toLowerCase()
   return aName.replace(REGEX, '').localeCompare(bName.replace(REGEX, '')) || aName.localeCompare(bName)
-}
-
-function formatPluginName(string) {
-  const name = string.toLowerCase()
-  const isInternal = name.match(/^@netlify\/plugin/)
-
-  const cleanName = toTitleCase(name
-    .replace(REGEX, '')
-    .replace(/^@netlify\/plugin/, '')
-    .replace(/-/g, ' ')
-    .replace(/plugin$/g, '')
-    .trim()
-  )
-  return (isInternal) ? `${cleanName} plugin` : cleanName
-}
-
-function toTitleCase(str) {
-  return str.replace(/\w\S*/g, function(txt) {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-  })
 }
 
 markdownMagic(MARKDOWN_PATH, mdConfig, () => {

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -33,7 +33,7 @@ const mdConfig = {
       md += `| Plugin | Author |\n`
       md += '|:---------------------------|:-----------:|\n'
       PLUGINS.sort(sortPlugins).forEach((data) => {
-        const userName = username(data.repo)
+        const userName = data.author;
         const profileURL = `https://github.com/${userName}`
         md += `| **[${formatPluginName(data.name)} - \`${data.name.toLowerCase()}\`](${data.repo})** <br/> `
         md += ` ${data.description} | `
@@ -49,22 +49,6 @@ function sortPlugins(a, b) {
   const aName = a.name.toLowerCase()
   const bName = b.name.toLowerCase()
   return aName.replace(REGEX, '').localeCompare(bName.replace(REGEX, '')) || aName.localeCompare(bName)
-}
-
-function username(repo) {
-  if (!repo) {
-    return null
-  }
-
-  const o = url.parse(repo)
-  let path = o.path
-
-  if (path.length && path.charAt(0) === '/') {
-    path = path.slice(1)
-  }
-
-  path = path.split('/')[0]
-  return path
 }
 
 function formatPluginName(string) {


### PR DESCRIPTION
Solves #4 adding `author` property per plugin.

It also renames `name` property as `package`, and adds a `name` property to avoid humanizing from IDs.