### PR TITLE
Temporarily hide Gatsby plugin from the UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,19 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **19** 🎉
+Plugin count: **18** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
 | **[A11y - `netlify-plugin-a11y`](https://github.com/sw-yx/netlify-plugin-a11y)** <br/>  Build a more accessible web! Run your critical pages through pa11y and fail build if accessibility failures are found. | [sw-yx](https://github.com/sw-yx) |
 | **[Build Plugin Speedcurve - `netlify-build-plugin-speedcurve`](https://github.com/tkadlec/netlify-build-plugin-speedcurve)** <br/>  After a successful build, tell SpeedCurve you've deployed and trigger a round of testing | [tkadlec](https://github.com/tkadlec) |
-| **[Cache Nextjs - `netlify-plugin-cache-nextjs`](https://github.com/pizzafox/netlify-cache-nextjs)** <br/>  Cache the .next folder in Netlify builds | [pizzafox](https://github.com/pizzafox) |
+| **[Cache Next.js - `netlify-plugin-cache-nextjs`](https://github.com/pizzafox/netlify-cache-nextjs)** <br/>  Cache the .next build folder between builds | [pizzafox](https://github.com/pizzafox) |
 | **[Checklinks - `netlify-plugin-checklinks`](https://github.com/munter/netlify-plugin-checklinks)** <br/>  Checklinks helps you keep all your asset references correct and avoid embarrassing broken links to your internal pages, or even to external pages you link out to. | [munter](https://github.com/munter) |
 | **[Cypress - `netlify-plugin-cypress`](https://github.com/cypress-io/netlify-plugin-cypress)** <br/>  Runs Cypress end-to-end tests after Netlify builds the site | [bahmutov](https://github.com/bahmutov) |
 | **[Debug Cache - `netlify-plugin-debug-cache`](https://github.com/netlify-labs/netlify-plugin-debug-cache)** <br/>  Debug & verify the contents of your Netlify build cache | [netlify-labs](https://github.com/netlify-labs) |
 | **[Deployment Hours - `netlify-deployment-hours-plugin`](https://github.com/neverendingqs/netlify-deployment-hours-plugin)** <br/>  A Netlify build plugin that blocks deployment if it outside of deployment hours. | [neverendingqs](https://github.com/neverendingqs) |
 | **[Encrypted Files - `netlify-plugin-encrypted-files`](https://github.com/sw-yx/netlify-plugin-encrypted-files)** <br/>  Netlify Build Plugin to partially obscure files (names and contents) in git repos! This enables you to partially open source your site, while still being able to work as normal on your local machine and in your Netlify builds. | [sw-yx](https://github.com/sw-yx) |
 | **[Fetch Feeds - `netlify-plugin-fetch-feeds`](https://github.com/philhawksworth/netlify-plugin-fetch-feeds)** <br/>  A Netlify plugin to source content from remote feeds including RSS and JSON | [philhawksworth](https://github.com/philhawksworth) |
-| **[Gatsby Cache - `netlify-plugin-gatsby-cache`](https://github.com/jlengstorf/netlify-plugin-gatsby-cache)** <br/>  Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️ | [jlengstorf](https://github.com/jlengstorf) |
 | **[Ghost Markdown - `netlify-plugin-ghost-markdown`](https://github.com/daviddarnes/netlify-plugin-ghost-markdown)** <br/>  Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API. | [daviddarnes](https://github.com/daviddarnes) |
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
 | **[Image Optim - `netlify-plugin-image-optim`](https://github.com/chrisdwheatley/netlify-plugin-image-optim)** <br/>  Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats. | [chrisdwheatley](https://github.com/chrisdwheatley) |

--- a/plugins.json
+++ b/plugins.json
@@ -56,13 +56,6 @@
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim"
   },
   {
-    "author": "jlengstorf",
-    "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️",
-    "name": "Gatsby Cache",
-    "package": "netlify-plugin-gatsby-cache",
-    "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache"
-  },
-  {
     "author": "pizzafox",
     "description": "Cache the .next build folder between builds",
     "name": "Cache Next.js",


### PR DESCRIPTION
There are [some issues](https://github.com/netlify/build/issues/1069#issuecomment-606057886) with the [Gatsby plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache) which currently make builds crash. 

We should temporarily hide this plugin from the UI until those issues are fixed.

Note: this is a featured plugin, so do we also need to update this in the database?