### PR TITLE
Adds netlify-plugin-prisma-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **19** 🎉
+Plugin count: **20** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
@@ -29,6 +29,7 @@ Plugin count: **19** 🎉
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
 | **[Image Optim - `netlify-plugin-image-optim`](https://github.com/chrisdwheatley/netlify-plugin-image-optim)** <br/>  Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats. | [chrisdwheatley](https://github.com/chrisdwheatley) |
 | **[No More 404 - `netlify-plugin-no-more-404`](https://github.com/sw-yx/netlify-plugin-no-more-404)** <br/>  Check that you preserve your own internal URL structure between builds, accounting for Netlify Redirects. Don't break the web! | [sw-yx](https://github.com/sw-yx) |
+| **[Prisma Provider - `netlify-plugin-prisma-provider`](https://github.com/redwoodjs/netlify-plugin-prisma-provider)** <br/>  Replaces the database provider in Prisma's schema.prisma at build time | [cannikin](https://github.com/cannikin) |
 | **[RSS - `netlify-plugin-rss`](https://github.com/sw-yx/netlify-plugin-rss)** <br/>  Generate an RSS feed from your static html files, agnostic of static site generator! | [sw-yx](https://github.com/sw-yx) |
 | **[Search Index - `netlify-plugin-search-index`](https://github.com/sw-yx/netlify-plugin-search-index)** <br/>  Generate a Search Index of your site you can query via JavaScript or a Netlify Function | [sw-yx](https://github.com/sw-yx) |
 | **[Sitemap plugin - `@netlify/plugin-sitemap`](https://github.com/netlify-labs/netlify-plugin-sitemap)** <br/>  Automatically generate a sitemap for your site on PostBuild in Netlify | [netlify-labs](https://github.com/netlify-labs) |

--- a/plugins.json
+++ b/plugins.json
@@ -131,5 +131,12 @@
     "name": "Cypress",
     "package": "netlify-plugin-cypress",
     "repo": "https://github.com/cypress-io/netlify-plugin-cypress"
+  },
+  {
+    "author": "cannikin",
+    "description": "Replaces the database provider in Prisma's schema.prisma at build time",
+    "name": "Prisma Provider",
+    "package": "netlify-plugin-prisma-provider",
+    "repo": "https://github.com/redwoodjs/netlify-plugin-prisma-provider"
   }
 ]


### PR DESCRIPTION
I created this plugin which makes Redwood production deploys MUCH easier until Prisma gets around to fixing [this issue](https://github.com/prisma/prisma2/issues/1487), but it should be helpful to anyone deploying Prisma to production.