### PR TITLE
Remove plugins with outdated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **20** 🎉
+Plugin count: **17** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
@@ -23,18 +23,15 @@ Plugin count: **20** 🎉
 | **[Debug Cache - `netlify-plugin-debug-cache`](https://github.com/netlify-labs/netlify-plugin-debug-cache)** <br/>  Debug & verify the contents of your Netlify build cache | [netlify-labs](https://github.com/netlify-labs) |
 | **[Deployment Hours - `netlify-deployment-hours-plugin`](https://github.com/neverendingqs/netlify-deployment-hours-plugin)** <br/>  A Netlify build plugin that blocks deployment if it is outside of deployment hours. | [neverendingqs](https://github.com/neverendingqs) |
 | **[Encrypted Files - `netlify-plugin-encrypted-files`](https://github.com/sw-yx/netlify-plugin-encrypted-files)** <br/>  Netlify Build Plugin to partially obscure files (names and contents) in git repos! This enables you to partially open source your site, while still being able to work as normal on your local machine and in your Netlify builds. | [sw-yx](https://github.com/sw-yx) |
-| **[Fetch Feeds - `netlify-plugin-fetch-feeds`](https://github.com/philhawksworth/netlify-plugin-fetch-feeds)** <br/>  A Netlify plugin to source content from remote feeds including RSS and JSON | [philhawksworth](https://github.com/philhawksworth) |
 | **[Gatsby Cache - `netlify-plugin-gatsby-cache`](https://github.com/jlengstorf/netlify-plugin-gatsby-cache)** <br/>  Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️ | [jlengstorf](https://github.com/jlengstorf) |
 | **[Ghost Markdown - `netlify-plugin-ghost-markdown`](https://github.com/daviddarnes/netlify-plugin-ghost-markdown)** <br/>  Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API. | [daviddarnes](https://github.com/daviddarnes) |
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
-| **[Image Optim - `netlify-plugin-image-optim`](https://github.com/chrisdwheatley/netlify-plugin-image-optim)** <br/>  Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats. | [chrisdwheatley](https://github.com/chrisdwheatley) |
 | **[No More 404 - `netlify-plugin-no-more-404`](https://github.com/sw-yx/netlify-plugin-no-more-404)** <br/>  Check that you preserve your own internal URL structure between builds, accounting for Netlify Redirects. Don't break the web! | [sw-yx](https://github.com/sw-yx) |
 | **[Prisma Provider - `netlify-plugin-prisma-provider`](https://github.com/redwoodjs/netlify-plugin-prisma-provider)** <br/>  Replaces the database provider in Prisma's schema.prisma at build time | [cannikin](https://github.com/cannikin) |
 | **[RSS - `netlify-plugin-rss`](https://github.com/sw-yx/netlify-plugin-rss)** <br/>  Generate an RSS feed from your static html files, agnostic of static site generator! | [sw-yx](https://github.com/sw-yx) |
 | **[Search Index - `netlify-plugin-search-index`](https://github.com/sw-yx/netlify-plugin-search-index)** <br/>  Generate a Search Index of your site you can query via JavaScript or a Netlify Function | [sw-yx](https://github.com/sw-yx) |
 | **[Sitemap plugin - `@netlify/plugin-sitemap`](https://github.com/netlify-labs/netlify-plugin-sitemap)** <br/>  Automatically generate a sitemap for your site on PostBuild in Netlify | [netlify-labs](https://github.com/netlify-labs) |
 | **[Subfont - `netlify-plugin-subfont`](https://github.com/munter/netlify-plugin-subfont)** <br/>  Subfont post-processes your web page to analyse you usage of web fonts, then reworks your webpage to use an optimal font loading strategy for the best performance. | [munter](https://github.com/munter) |
-| **[Yield Data For Eleventy - `netlify-plugin-yield-data-for-eleventy`](https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy)** <br/>  A Netlify plugin to expose data collected to in the Netlify build cache to place and structure that Eleventy can use | [philhawksworth](https://github.com/philhawksworth) |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').

--- a/plugins.json
+++ b/plugins.json
@@ -35,27 +35,6 @@
     "repo": "https://github.com/neverendingqs/netlify-deployment-hours-plugin"
   },
   {
-    "author": "philhawksworth",
-    "description": "A Netlify plugin to source content from remote feeds including RSS and JSON",
-    "name": "Fetch Feeds",
-    "package": "netlify-plugin-fetch-feeds",
-    "repo": "https://github.com/philhawksworth/netlify-plugin-fetch-feeds"
-  },
-  {
-    "author": "philhawksworth",
-    "description": "A Netlify plugin to expose data collected to in the Netlify build cache to place and structure that Eleventy can use",
-    "name": "Yield Data For Eleventy",
-    "package": "netlify-plugin-yield-data-for-eleventy",
-    "repo": "https://github.com/philhawksworth/netlify-plugin-yield-data-for-eleventy"
-  },
-  {
-    "author": "chrisdwheatley",
-    "description": "Optimize images as part of your Netlify build process. Optimizes PNG, JPEG, GIF and SVG file formats.",
-    "name": "Image Optim",
-    "package": "netlify-plugin-image-optim",
-    "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim"
-  },
-  {
     "author": "jlengstorf",
     "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️",
     "name": "Gatsby Cache",


### PR DESCRIPTION
All plugins listed in https://github.com/netlify/plugins/blob/master/plugins.json now display in the Netlify UI. To ensure a consistent installation experience all plugins listed there, I did a survey of all plugins in the list and made PRs to update their READMEs a few weeks ago.

There are a few that still need some updates, so I'm removing them from the list for now. They can be re-added when they're up to date and tested!