### PR TITLE
Add netlify-plugin-out-of-minutes

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4,7 +4,8 @@
     "description": "Cancel a build early if you donʼt have enough build minutes.",
     "name": "Out of Minutes",
     "package": "netlify-plugin-out-of-minutes",
-    "repo": "https://github.com/williamjacksn/netlify-plugin-out-of-minutes"
+    "repo": "https://github.com/williamjacksn/netlify-plugin-out-of-minutes",
+    "version": "1.1.0"
   },
   {
     "author": "tkadlec",

--- a/plugins.json
+++ b/plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "author": "williamjacksn",
+    "description": "Cancel a build early if you donʼt have enough build minutes.",
+    "name": "Out of Minutes",
+    "package": "netlify-plugin-out-of-minutes",
+    "repo": "https://github.com/williamjacksn/netlify-plugin-out-of-minutes"
+  },
+  {
     "author": "tkadlec",
     "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
     "name": "Build Plugin Speedcurve",


### PR DESCRIPTION
I wrote a build plugin that will cancel a build if there are not enough build minutes left.