### PR TITLE
Add inline critical CSS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below are plugins created by some awesome people! ❤️
 To add a plugin, add informations to the [plugins.json file]('./plugins.json').
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
-Plugin count: **20** 🎉
+Plugin count: **21** 🎉
 
 | Plugin | Author |
 |:---------------------------|:-----------:|
@@ -27,6 +27,7 @@ Plugin count: **20** 🎉
 | **[Gatsby Cache - `netlify-plugin-gatsby-cache`](https://github.com/jlengstorf/netlify-plugin-gatsby-cache)** <br/>  Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️ | [jlengstorf](https://github.com/jlengstorf) |
 | **[Ghost Markdown - `netlify-plugin-ghost-markdown`](https://github.com/daviddarnes/netlify-plugin-ghost-markdown)** <br/>  Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API. | [daviddarnes](https://github.com/daviddarnes) |
 | **[Hashfiles - `netlify-plugin-hashfiles`](https://github.com/munter/netlify-plugin-hashfiles)** <br/>  Hashfiles sets you up with an optimal caching strategy for static sites, where static assets across pages are cached for as long as possible in the visitors browser and never have to be re-requested. | [munter](https://github.com/munter) |
+| **[Inline critical CSS - `netlify-plugin-inline-critical-css`](https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css)** <br/>  Automatically extract and inline the critical CSS of your pages in order to render content to the user as fast as possible. | [Tom-Bonnike](https://github.com/Tom-Bonnike) |
 | **[Inline source - `netlify-plugin-inline-source`](https://github.com/Tom-Bonnike/netlify-plugin-inline-source)** <br/>  Improve your site’s performance by inlining some of your assets/sources, reducing the number of HTTP requests your users need to make. | [Tom-Bonnike](https://github.com/Tom-Bonnike) |
 | **[Next.js Cache - `netlify-plugin-cache-nextjs`](https://github.com/pizzafox/netlify-cache-nextjs)** <br/>  Cache the .next build folder between builds | [pizzafox](https://github.com/pizzafox) |
 | **[No More 404 - `netlify-plugin-no-more-404`](https://github.com/sw-yx/netlify-plugin-no-more-404)** <br/>  Check that you preserve your own internal URL structure between builds, accounting for Netlify Redirects. Don't break the web! | [sw-yx](https://github.com/sw-yx) |

--- a/plugins.json
+++ b/plugins.json
@@ -138,5 +138,13 @@
     "name": "Inline source",
     "package": "netlify-plugin-inline-source",
     "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-source"
+  },
+  {
+    "author": "Tom-Bonnike",
+    "description": "Automatically extract and inline the critical CSS of your pages in order to render content to the user as fast as possible.",
+    "name": "Inline critical CSS",
+    "package": "netlify-plugin-inline-critical-css",
+    "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css",
+    "version": "1.0.3"
   }
 ]


### PR DESCRIPTION
Hi. After having created the inline source plugin, I realized it’d be great to have a plugin to automatically inline critical CSS across many pages. [`critical`](https://github.com/addyosmani/critical) makes this very easy, so today I spent some time to create a [plugin](https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css) with sensible defaults. I tried it on a small Jekyll website and it seems to work as expected, but I’d love if you folks could also test it on your own websites before merging.

---

One small issue is that `critical` relies on Node v10 and, as you [probably know](https://github.com/netlify/build/issues/1239), the Ubuntu Xenial build image still uses v8 by default. I think [this issue](https://github.com/netlify/build/issues/1247) is a great idea, most users will need a better hint than a stack trace 👍
For now, I’m not sure what I should do as a plugin maintainer? Should I just leave a warning in the README? I don’t really want to have to compile my plugin. 😄 I did put an `engines` field in my `package.json` but there is no warning from npm.

---

 I’m thinking of creating a third plugin built on top of `uncss` too, I’ll work on this whenever I’ll have time 🧛‍♂️ 