### PR TITLE
Fix plugins.json file url typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information see the [@Netlify/build](https://github.com/netlify/build) 
 
 Below are plugins created by some awesome people! ❤️
 
-To add a plugin, add informations to the [plugins.json file]('./plugins.json').
+To add a plugin, add informations to the [plugins.json file](./plugins.json).
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_PLUGIN_TABLE)-->
 Plugin count: **30** 🎉


### PR DESCRIPTION
Currently plugins.json file's url is broken due to typo. This PR fixes that. 