### PR TITLE
Temporarily disable some plugins

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -93,7 +93,8 @@
     "name": "Get Environment Variables",
     "package": "netlify-plugin-get-env-vars",
     "repo": "https://github.com/shortdiv/netlify-plugin-get-env-vars",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "shortdiv",
@@ -101,7 +102,8 @@
     "name": "Prerender SPA",
     "package": "netlify-plugin-prerender-spa",
     "repo": "https://github.com/shortdiv/netlify-plugin-prerender-spa",
-    "version": "1.0.1"
+    "version": "1.0.1",
+    "status": "DEACTIVATED"
   },
   {
     "author": "sw-yx",
@@ -117,7 +119,8 @@
     "name": "Encrypted Files",
     "package": "netlify-plugin-encrypted-files",
     "repo": "https://github.com/sw-yx/netlify-plugin-encrypted-files",
-    "version": "0.0.5"
+    "version": "0.0.5",
+    "status": "DEACTIVATED"
   },
   {
     "author": "sw-yx",
@@ -173,7 +176,8 @@
     "name": "Chromium",
     "package": "netlify-plugin-chromium",
     "repo": "https://github.com/soofka/netlify-plugin-chromium",
-    "version": "1.1.1"
+    "version": "1.1.1",
+    "status": "DEACTIVATED"
   },
   {
     "author": "Tom-Bonnike",
@@ -205,7 +209,8 @@
     "name": "Plugin To All Events",
     "package": "netlify-plugin-to-all-events",
     "repo": "https://github.com/tzmanics/netlify-plugin-to-all-events",
-    "version": "1.3.1"
+    "version": "1.3.1",
+    "status": "DEACTIVATED"
   },
   {
     "author": "philhawksworth",


### PR DESCRIPTION
Support for some deprecated syntax used by few plugins is being removed. This will break those plugins, making builds using them crash in production.

This PR temporarily removes those plugins from Netlify UI.

PRs were sent to each of those plugins to use the new syntax, as listed [here](https://github.com/netlify/build/issues/1068#issuecomment-631741188). 

We should re-enable each of those plugins as soon as: 
  1. Those PRs are merged
  2. A new npm release is made
  3. A PR is sent to this repository to update the `version` field in `plugins.json`

The list of plugins is:
  - `netlify-plugin-get-env-vars` by @shortdiv ([PR 1](https://github.com/shortdiv/netlify-plugin-get-env-vars/pull/4))
  - `netlify-plugin-prerender-spa` by @shortdiv ([PR 1](https://github.com/shortdiv/netlify-plugin-prerender-spa/pull/3))
  - `netlify-plugin-encrypted-files` by @sw-yx ([PR 1](https://github.com/sw-yx/netlify-plugin-encrypted-files/pull/3), [PR 2](https://github.com/sw-yx/netlify-plugin-encrypted-files/pull/4), [PR 3](https://github.com/sw-yx/netlify-plugin-encrypted-files/pull/6))
  - `netlify-plugin-to-all-events` by @tzmanics ([PR 1](https://github.com/tzmanics/netlify-plugin-to-all-events/pull/1))
  - `netlify-plugin-chromium` by @soofka ([PR 1](https://github.com/soofka/netlify-plugin-chromium/pull/1), [PR 2](https://github.com/soofka/netlify-plugin-chromium/pull/2))