### PR TITLE
Upgrade version of Gatsby cache plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -45,7 +45,7 @@
     "name": "Gatsby Cache",
     "package": "netlify-plugin-gatsby-cache",
     "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache",
-    "version": "0.2.1"
+    "version": "0.3.0"
   },
   {
     "author": "jlengstorf",


### PR DESCRIPTION
This upgrades the version of the Gatsby cache plugin to include the latest changes from Netlify Build.