### PR TITLE
Bump inline-critical-css to 1.1.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -193,7 +193,7 @@
     "name": "Inline critical CSS",
     "package": "netlify-plugin-inline-critical-css",
     "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css",
-    "version": "1.0.4"
+    "version": "1.1.0"
   },
   {
     "author": "tzmanics",


### PR DESCRIPTION
1.1.0 contains an update to `critical` that improves the loading strategy for uncritical CSS files.
It now uses `media` switching instead of outputting a `loadCSS` script in the head.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

See this successful build: https://app.netlify.com/sites/tombonnike/deploys/5ecf96d16ae0cc00063ec34d

It now uses the `media` font loading strategy, as expected:
<img src="https://user-images.githubusercontent.com/9154236/83133443-2e1e9d00-a0e3-11ea-85cd-a9cfb0d49e99.png" />

⚠️ It seems like the “Bundle CSS” post-processing asset optimization messes up attributes, I opened an issue on the Build repository : https://github.com/netlify/build/issues/1384