### PR TITLE
bumping netlify-plugin-algolia-index version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5,7 +5,7 @@
     "name": "Algolia Search Index",
     "package": "netlify-plugin-algolia-index",
     "repo": "https://github.com/lukeocodes/netlify-plugin-algolia-index",
-    "version": "0.2.2"
+    "version": "0.3.0"
   },
   {
     "author": "tkadlec",


### PR DESCRIPTION
the plugin includes stopword removal at source and text truncation to meet algolia community-account export limits by default (each object needs to be below 10k bytes)

Thanks for contributing the the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
output of build with 0.3.0 https://vonage-dev-blog.netlify.app/build.output

once built, your route will include a searchIndex.json, the changes being that the text value of each object should now be less than your character limit, which has the result of limiting each object in the array to less than 10k bytes by default, which meets the restrictions of the algolia community-account export limits.