### PR TITLE
Adds Dareboost plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -293,6 +293,6 @@
     "name": "Dareboost",
     "package": "netlify-build-plugin-dareboost",
     "repo": "https://github.com/borisschapira/netlify-build-plugin-dareboost",
-    "version": "1.1.1"
+    "version": "1.2.0"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -286,5 +286,13 @@
     "package": "netlify-plugin-image-optim",
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim",
     "version": "0.3.0"
+  },
+  {
+    "author": "borisschapira",
+    "description": "After a successful build, creates an event into your Dareboost monitoring and launch some analyses.",
+    "name": "Dareboost",
+    "package": "netlify-build-plugin-dareboost",
+    "repo": "https://github.com/borisschapira/netlify-build-plugin-dareboost",
+    "version": "1.1.1"
   }
 ]


### PR DESCRIPTION
This is a plugin for Dareboost customers, so that they can automatically add an event matching the successful build into their monitoring graph, and launch new pages analyses on their target.

Most of the configuration is done through `inputs`, except for the Dareboost API token that you need to define in an env. variable (I didn't want people committing their token by mistake on a public repo). The token is not logged during the build ([example](https://app.netlify.com/sites/borisschapira/deploys/5ed17a00e9063e00061ca9c6)).

**Next:** trying to understand how to configure, in this `netlify.toml` file, different plugin inputs for different branches (or restrict the execution of a plugin to one branch only).

Thanks for contributing the the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

==> https://app.netlify.com/sites/borisschapira/deploys/5ed17a00e9063e00061ca9c6