### PR TITLE
Bump netlify-plugin-inline-critical-css to 1.1.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -202,7 +202,7 @@
     "name": "Inline critical CSS",
     "package": "netlify-plugin-inline-critical-css",
     "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   {
     "author": "tzmanics",


### PR DESCRIPTION
[Version 1.1.1](https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/commit/f0b181d345c9b74428057fa5ee76c95dd398ea86) stops processing multiple HTML files concurrently to try and fix:
- https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/5 (lingering puppeteer processes)
- https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/3 (out of memory issues)

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

https://app.netlify.com/sites/tombonnike/deploys/5ed0f71664437d0007563b2e

Obviously my test project is small, but if it works on one page it will work on multiple.
Not sure about the performance impact of that change, but it’s worth trying it to see if we get less errors. :)