### PR TITLE
Add npm diff to PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,10 @@ Thanks for contributing the the Netlify plugins directory!
 - [ ] Adding a plugin
 - [ ] Updating a plugin
 
-When updating a plugin, please fill the following link with the plugin name, old version and new version:
-https://diff.intrinsic.com/netlify-plugin-example/1.0.0/2.0.0
+**Plugin version diff**
+
+If updating a previously added package, create a diff at [diff.intrinsic.com](https://diff.intrinsic.com) and provide a link to the diff here.
+Example link: https://diff.intrinsic.com/@netlify/plugin-sitemap/0.3.3/0.3.4
 
 **Have you completed the following?**
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@ Thanks for contributing the the Netlify plugins directory!
 - [ ] Adding a plugin
 - [ ] Updating a plugin
 
+When updating a plugin, please fill the following link with the plugin name, old version and new version:
+https://diff.intrinsic.com/netlify-plugin-example/1.0.0/2.0.0
+
 **Have you completed the following?**
 
 - [ ] Read and followed the [plugin author guidelines](/docs/guidelines.md).


### PR DESCRIPTION
Related to #69.

This adds a npm diff to our PR template, so it's easy to check difference on plugin updates.