### PR TITLE
add opensearch plugin to netlify plugins

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -8,6 +8,14 @@
     "version": "0.3.0"
   },
   {
+    "author": "lukeocodes",
+    "description": "Automatically generate opensearch search.xml file postBuild on Netlify deploy",
+    "name": "Opensearch File Automation",
+    "package": "netlify-plugin-opensearch",
+    "repo": "https://github.com/lukeocodes/netlify-plugin-opensearch",
+    "version": "1.0.1"
+  },
+  {
     "author": "tkadlec",
     "description": "After a successful build, tell SpeedCurve you've deployed and trigger a round of testing",
     "name": "Build Plugin Speedcurve",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

successful build output: https://netlify-plugin-algolia-index.netlify.app/build.output

once added, even with blank options, will build a search.xml file which can be used for opensearch description of a site, allowing tab-to-search features in the browser.

https://netlify-plugin-algolia-index.netlify.app/search.xml is the result of the build.
