### PR TITLE
Bump netlify-plugin-pushover version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -261,7 +261,7 @@
     "name": "Pushover Notification",
     "package": "netlify-plugin-pushover",
     "repo": "https://github.com/AshikNesin/netlify-plugin-pushover",
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   {
     "author": "erezrokah",


### PR DESCRIPTION
Bumping the version to which has fix to **ensure confidential information is not printed in public logs** by @ehmicky 

https://github.com/AshikNesin/netlify-plugin-pushover/pull/3

Thanks for contributing the the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Plugin version diff**

If updating a previously added package, create a diff at [diff.intrinsic.com](https://diff.intrinsic.com) and provide a link to the diff here.
Example link: https://diff.intrinsic.com/@netlify/plugin-sitemap/0.3.3/0.3.4

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
