### PR TITLE
Bump netlify-build-plugin-dareboost

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -297,11 +297,11 @@
   },
   {
     "author": "borisschapira",
-    "description": "After a successful build, creates an event into your Dareboost monitoring and launch some analyses.",
+    "description": "After a successful build, create an event in your Dareboost monitoring. If you have subscribed to API credits, you can automatically launch analyses.",
     "name": "Dareboost",
     "package": "netlify-build-plugin-dareboost",
     "repo": "https://github.com/borisschapira/netlify-build-plugin-dareboost",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   {
     "author": "cdeleeuwe",


### PR DESCRIPTION
_This a fix for https://github.com/borisschapira/netlify-build-plugin-dareboost/issues/3, because I missed in 1.2.0 that `utils.status.show() "text" property must be a non-empty string`._

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [X] Updating a plugin

**Plugin version diff**

https://diff.intrinsic.com/netlify-build-plugin-dareboost/1.2.0/1.2.1

**Have you completed the following?**

- [X] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [X] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [X] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

https://app.netlify.com/sites/borisschapira/deploys/5ee12faef49e1a0007b1b6a4
