### PR TITLE
ci(npm-diff): use custom token with write permissions

### DIFF
--- a/.github/workflows/npmDiff.yml
+++ b/.github/workflows/npmDiff.yml
@@ -40,4 +40,4 @@ jobs:
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NETLIBOT }}


### PR DESCRIPTION
Follow up on https://github.com/netlify/plugins/issues/69

Uses a token with write permissions to support commenting on PRs coming from forks.

Also adds some error handling and reporting