### PR TITLE
Bump and activate netlify-plugin-chromium

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -193,8 +193,7 @@
     "name": "Chromium",
     "package": "netlify-plugin-chromium",
     "repo": "https://github.com/soofka/netlify-plugin-chromium",
-    "version": "1.1.1",
-    "status": "DEACTIVATED"
+    "version": "1.1.3"
   },
   {
     "author": "Tom-Bonnike",

--- a/plugins.json
+++ b/plugins.json
@@ -193,7 +193,7 @@
     "name": "Chromium",
     "package": "netlify-plugin-chromium",
     "repo": "https://github.com/soofka/netlify-plugin-chromium",
-    "version": "1.1.3"
+    "version": "1.1.4"
   },
   {
     "author": "Tom-Bonnike",


### PR DESCRIPTION
Thanks for contributing the the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Plugin version diff**

https://diff.intrinsic.com/netlify-plugin-chromium/1.1.1/1.1.4

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/amazing-morse-5b1303/deploys/5ee27b6145fc4e0007a159df

Between 8:44:57 and 8:45:27 the plugin is triggered and you can see Chromium being installed. Then at 8:46:24 Lighthouse CI is triggered and Chromium is recognized as available, thus further steps of Lighthouse process are performed.
