### PR TITLE
Bump netlify-plugin-inline-critical-css to 1.1.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -209,7 +209,7 @@
     "name": "Inline critical CSS",
     "package": "netlify-plugin-inline-critical-css",
     "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css",
-    "version": "1.1.1"
+    "version": "1.1.3"
   },
   {
     "author": "tzmanics",


### PR DESCRIPTION
**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Plugin version diff**

- Fix for https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/8 (`critical` bump)
- Attempts at fixing (or at least limiting) https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/5

https://diff.intrinsic.com/netlify-plugin-inline-critical-css/1.1.1/1.1.3

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

https://app.netlify.com/sites/tombonnike/deploys/5eecf18b59c7d0bb5d2f651f