### PR TITLE
Revert Algolia breaking changes

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -9,11 +9,11 @@
   },
   {
     "author": "lukeocodes",
-    "description": "Generate and export a search index direct to Algolia",
+    "description": "Generate an Algolia friendly Search Index of your site",
     "name": "Algolia Search Index",
     "package": "netlify-plugin-algolia-index",
     "repo": "https://github.com/lukeocodes/netlify-plugin-algolia-index",
-    "version": "1.0.2"
+    "version": "0.3.0"
   },
   {
     "author": "tkadlec",


### PR DESCRIPTION
An update to the Algolia plugin got merged by #98.

This update includes some breaking changes: some additional environment variables (with Algolia credentials) are now required.

Unfortunately, we don't support breaking changes in plugins yet. We are still working on what the best experience for plugin users is when it comes to major releases. This means this update would make the builds of every user of that plugin break.

This PR reverts #98 so we can think of a solution to this problem.

Since designing breaking changes support might take some time, I would suggest this: publish the new major release under a different npm package name, and add this instead. What do you think?

@erquhart @lukeocodes 