### PR TITLE
chore: bump visual diff version to 1.2.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -77,7 +77,7 @@
     "name": "Visual Diff (Applitools)",
     "package": "netlify-plugin-visual-diff",
     "repo": "https://github.com/jlengstorf/netlify-plugin-visual-diff",
-    "version": "1.1.3"
+    "version": "1.2.0"
   },
   {
     "author": "pizzafox",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Plugin version diff**

https://diff.intrinsic.com/netlify-plugin-visual-diff/1.1.3/1.2.0

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
