### PR TITLE
docs(pr-template): remove manual npm diff instruction

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,6 @@ Thanks for contributing the Netlify plugins directory!
 - [ ] Adding a plugin
 - [ ] Updating a plugin
 
-**Plugin version diff**
-
-If updating a previously added package, create a diff at [diff.intrinsic.com](https://diff.intrinsic.com) and provide a link to the diff here.
-Example link: https://diff.intrinsic.com/@netlify/plugin-sitemap/0.3.3/0.3.4
-
 **Have you completed the following?**
 
 - [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).


### PR DESCRIPTION
The manual step is no longer required as we do it automatically via a Netlifunction:
https://github.com/netlify/plugins/blob/d8421b4fa305267fe078e8658dd851e749b0596d/functions/npm-diff.js