### PR TITLE
feat: add netlify-purge-cloudflare-cache

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -357,5 +357,13 @@
     "package": "netlify-build-plugin-perfbeacon",
     "repo": "https://github.com/perfbeacon/netlify-build-plugin-perfbeacon",
     "version": "1.0.3"
+  },
+  {
+    "author": "nikduvall",
+    "description": "Clear Cloudflare cache when build completes using API Token Authentication (more secure than global API Key)",
+    "name": "Cloudflare Cache Purge using API Token Authentication",
+    "package": "netlify-purge-cloudflare-cache",
+    "repo": "https://github.com/nikduvall/netlify-purge-cloudflare-cache",
+    "version": "1.0.1"
   }
 ]


### PR DESCRIPTION
This is a fork of chrism2671/netlify-purge-cloudflare-on-deploy that I have updated to use the newer API Tokens instead of the older API Keys authentication method, which is Cloudflare's recommended method of authentication because its use can be restricted to specific actions whereas the API Key gives full unrestricted access to all functions fo the account.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [X] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [X] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [X] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [X] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/dev-duvee-digital/deploys/5f12e8700adf280008442d94
