### PR TITLE
feat: add netlify-plugin-next-dynamic

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -357,5 +357,13 @@
     "package": "netlify-build-plugin-perfbeacon",
     "repo": "https://github.com/perfbeacon/netlify-build-plugin-perfbeacon",
     "version": "1.0.3"
+  },
+  {
+    "author": "rayriffy",
+    "description": "Netlify plugin that allows you to deploy dynamic NextJS path statically",
+    "name": "Next Dynamic Routes",
+    "package": "netlify-plugin-next-dynamic",
+    "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
+    "version": "1.0.6"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -364,6 +364,6 @@
     "name": "Next Dynamic Routes",
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
-    "version": "1.0.6"
+    "version": "1.0.7"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -364,6 +364,6 @@
     "name": "Next Dynamic Routes",
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
-    "version": "1.0.7"
+    "version": "1.0.8"
   }
 ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Basically, many people who use next as static export cannot use dynamic routes with Netlify unless they will going to **manually** write redirects. This plugin automate all of that

Full demo: https://demo-netlify-plugin-next-dynamic.netlify.app/

Source: https://github.com/Brikl/demo-netlify-plugin-next-dynamic

Successful deploy log: https://app.netlify.com/sites/demo-netlify-plugin-next-dynamic/deploys/5f1986636a6fd38c42e29609
