### PR TITLE
chore: update netlify-plugin-next-dynamic to 1.0.9

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -364,6 +364,6 @@
     "name": "Next Dynamic Routes",
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
-    "version": "1.0.8"
+    "version": "1.0.9"
   }
 ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

This is an update for issue Brikl/opensource#6 which patched and updated in Brikl/opensource#7
