### PR TITLE
Add netlify-plugin-redirects to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -365,5 +365,13 @@
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
     "version": "1.0.9"
+  },
+  {
+    "author": "tcmacdonald",
+    "description": "Generate _redirects with environment variables and context support",
+    "name": "ENV Redirects",
+    "package": "netlify-plugin-redirects",
+    "repo": "https://github.com/ample/netlify-plugin-redirects",
+    "version": "1.2.0"
   }
 ]


### PR DESCRIPTION
This PR adds [netlify-plugin-redirects](https://www.npmjs.com/package/@helloample/netlify-plugin-redirects) to `plugins.json`. This build plugin interpolates environment variables and context associated with redirect rules and writes them to the `_redirects` file during the `onPostBuild` life-cycle event. 

Thanks for your consideration!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
You can see a demo implementation [here](https://github.com/ample/netlify-plugin-redirects-demo). The build logs are public and viewed [here](https://app.netlify.com/sites/netlify-plugin-redirects-demo/deploys/5f2c6f6d0d2a4d0008c4a90a). 