### PR TITLE
Add netlify-plugin-replace to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -365,5 +365,13 @@
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
     "version": "1.0.9"
+  },
+  {
+    "author": "tcmacdonald",
+    "description": "Netlify plugin to replace ENV variables in publish directory",
+    "name": "Replace",
+    "package": "netlify-plugin-replace",
+    "repo": "https://github.com/ample/netlify-plugin-replace",
+    "version": "1.0.0"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -372,6 +372,6 @@
     "name": "Replace",
     "package": "netlify-plugin-replace",
     "repo": "https://github.com/ample/netlify-plugin-replace",
-    "version": "1.0.0"
+    "version": "1.1.1"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -372,6 +372,6 @@
     "name": "Replace",
     "package": "netlify-plugin-replace",
     "repo": "https://github.com/ample/netlify-plugin-replace",
-    "version": "1.1.1"
+    "version": "1.1.2"
   }
 ]


### PR DESCRIPTION
This PR adds [netlify-plugin-replace](https://github.com/ample/netlify-plugin-replace) to `plugins.json`. This build plugin replaces environment variables in the project's publish directory during the `onPostBuild` life-cycle event.

This PR replaces #128– thanks @ehmicky for the thoughtful suggestions! Appreciate your consideration :) 

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
You can see a demo implementation [here](https://github.com/ample/netlify-plugin-replace-demo). The build logs are public and can be viewed [here](https://app.netlify.com/sites/netlify-plugin-replace-demo/deploys/5f4957037816aa0007cb879b).