### PR TITLE
Add netlify-build-plugin-debugbear

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -373,5 +373,13 @@
     "package": "@helloample/netlify-plugin-replace",
     "repo": "https://github.com/ample/netlify-plugin-replace",
     "version": "1.1.3"
+  },
+  {
+    "author": "mattzeunert",
+    "description": "Run tests on DebugBear to see how your deployments affect page performance and Lighthouse scores.",
+    "name": "DebugBear Web Performance",
+    "package": "netlify-build-plugin-debugbear",
+    "repo": "https://github.com/DebugBear/netlify-build-plugin-debugbear",
+    "version": "1.0.3"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -376,7 +376,7 @@
   },
   {
     "author": "mattzeunert",
-    "description": "Run tests on DebugBear to see how your deployments affect page performance and Lighthouse scores.",
+    "description": "Run tests on DebugBear to see how your deployments affect page performance and Lighthouse scores",
     "name": "DebugBear Web Performance",
     "package": "netlify-build-plugin-debugbear",
     "repo": "https://github.com/DebugBear/netlify-build-plugin-debugbear",

--- a/plugins.json
+++ b/plugins.json
@@ -380,6 +380,6 @@
     "name": "DebugBear Web Performance",
     "package": "netlify-build-plugin-debugbear",
     "repo": "https://github.com/DebugBear/netlify-build-plugin-debugbear",
-    "version": "1.0.3"
+    "version": "1.0.4"
   }
 ]


### PR DESCRIPTION
This plugin makes it easy for DebugBear customers to test each deployment and see how it affected page performance and Lighthouse scores.

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Deploy log: https://app.netlify.com/sites/mystifying-kilby-0e6399/deploys/5f4f59471ee5720008aeeded

---

I've considered using `utils.status.show()` to show the test result links, but it seems this still isn't supported on the Netlify website.
