### PR TITLE
fix: update netlify-plugin-is-website-vulnerable

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -284,7 +284,7 @@
     "name": "Is Website Vulnerable",
     "package": "netlify-plugin-is-website-vulnerable",
     "repo": "https://github.com/erezrokah/netlify-plugin-is-website-vulnerable",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   {
     "author": "martinbean",


### PR DESCRIPTION
Changed the plugin to use `onPostBuild` instead of `onSuccess`

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/nostalgic-hamilton-c4070a/deploys/5f510e5a127da60008fcb990
https://app.netlify.com/sites/nostalgic-hamilton-c4070a/deploys/5f511223c9b1bb0008a0db81