### PR TITLE
fix: update netlify-plugin-lighthouse

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -340,7 +340,7 @@
     "name": "Lighthouse",
     "package": "@netlify/plugin-lighthouse",
     "repo": "https://github.com/netlify-labs/netlify-plugin-lighthouse",
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   {
     "author": "oliverroick",


### PR DESCRIPTION
Changed the plugin to use `onPostBuild` instead of `onSuccess`

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/plugin-lighthouse/deploys/5f5127167ee09a0007295fb7