### PR TITLE
Update DebugBear plugin error handling

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -380,6 +380,6 @@
     "name": "DebugBear Web Performance",
     "package": "netlify-build-plugin-debugbear",
     "repo": "https://github.com/DebugBear/netlify-build-plugin-debugbear",
-    "version": "1.0.4"
+    "version": "1.0.6"
   }
 ]


### PR DESCRIPTION
This [fixes](https://github.com/DebugBear/netlify-build-plugin-debugbear/commit/186a9c30162ac9e443fc235546a77c301d9b6fec) the [issue reported here](https://github.com/DebugBear/netlify-build-plugin-debugbear/issues/4), where API errors are reported as plugin errors.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Run a test and provide an invalid API key.

![Screenshot 2020-09-06 at 12 34 32](https://user-images.githubusercontent.com/1303660/92324863-9ca5bc00-f03d-11ea-84a4-a912dc50898c.png)
