### PR TITLE
Bump version of netlify-plugin-replace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -372,7 +372,7 @@
     "name": "Replace",
     "package": "@helloample/netlify-plugin-replace",
     "repo": "https://github.com/ample/netlify-plugin-replace",
-    "version": "1.1.3"
+    "version": "1.1.4"
   },
   {
     "author": "mattzeunert",


### PR DESCRIPTION
This PR updates [netlify-plugin-replace](https://www.npmjs.com/package/@helloample/netlify-plugin-replace) to the latest version to correct an issue when the publish directory is included in the `.gitignore` file. 

When the publish directory is ignored, no replacements are made which can lead to some confusion as lots of SSGs follow this convention of not committing the build's output directory to revision control. Let me know if you have any questions. Thanks!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
The [demo application](https://github.com/ample/netlify-plugin-replace-demo) has been updated to reflect this new version. The latest build logs are accessible [here](https://app.netlify.com/sites/netlify-plugin-replace-demo/deploys/5f5a308b4258a20007fb125d). 