### PR TITLE
Deactivate netlify-plugin-algolia-index

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -13,7 +13,8 @@
     "name": "Algolia Search Index",
     "package": "netlify-plugin-algolia-index",
     "repo": "https://github.com/lukeocodes/netlify-plugin-algolia-index",
-    "version": "0.3.0"
+    "version": "0.3.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "tkadlec",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

Deactivating netlify-plugin-algolia-index because the [package is no longer maintained](https://github.com/lukeocodes/netlify-plugin-algolia-index#netlify-algolia-index-plugin). All new development has shifted to https://github.com/lukeocodes/netlify-plugin-algolia-export, which was submitted in https://github.com/netlify/plugins/pull/104.

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] (n/a) Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
n/a