### PR TITLE
Bump netlify-plugin-pushover version to v0.0.6

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -276,7 +276,7 @@
     "name": "Pushover Notification",
     "package": "netlify-plugin-pushover",
     "repo": "https://github.com/AshikNesin/netlify-plugin-pushover",
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   {
     "author": "erezrokah",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

## Change log

- [fix: switch to failPlugin instead of failBuild](https://github.com/AshikNesin/netlify-plugin-pushover/pull/5) by @erezrokah 