### PR TITLE
chore: bump image-optim version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -309,7 +309,7 @@
     "name": "Image Optim",
     "package": "netlify-plugin-image-optim",
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   {
     "author": "borisschapira",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

Successful public deploy log: https://app.netlify.com/sites/netlify-plugin-image-optim-test/deploys/5f8878af609fb50cd4505d65. Unfortnately I need to find some unoptimised images to make this test repo more useful but for now you can see it running successfully and it matches the output from [`imagemin-app`](https://github.com/imagemin/imagemin-app) (see screenshot below).

<img width="584" alt="Screen Shot 2020-10-15 at 17 42 44" src="https://user-images.githubusercontent.com/894092/96160438-de176a00-0f0d-11eb-8cb5-ba7e940b73fc.png">

