### PR TITLE
github tools: fix fossa workflow file

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,7 +20,7 @@ jobs:
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
           fossa init
       - name: Set env
-        run: echo ::set-env name=line_number::$(grep -n "project" .fossa.yml | cut -f1 -d:)
+        run: echo "line_number=$(grep -n "project" .fossa.yml | cut -f1 -d:)" >> $GITHUB_ENV
       - name: Configuration
         run: |-
           sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml


### PR DESCRIPTION
Updates github actions fossa workflow to use environment files instead of deprecated set-env command.