### PR TITLE
Update version  netlify-plugin-submit-sitemap

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -349,7 +349,7 @@
     "name": "Submit Sitemap",
     "package": "netlify-plugin-submit-sitemap",
     "repo": "https://github.com/cdeleeuwe/netlify-plugin-submit-sitemap",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   {
     "author": "netlify-labs",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
It's a minor update which checks if the build is run local. If so, it skip pinging the sitemaps.
