### PR TITLE
Publish to npm

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,4 +33,7 @@ Netlify will try to reach the plugin author(s), and if that fails, we will add a
 
 ## Releasing
 
-See the [documentation in the buildbot](https://github.com/netlify/buildbot/blob/master/docs/overview.md#build-plugins).
+```
+$ npm version major|minor|patch
+$ npm publish
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@netlify/plugins-list",
-  "private": true,
   "version": "1.0.0",
   "description": "List of Netlify plugins",
   "main": "site/plugins.json",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "netlify-plugins",
+  "name": "@netlify/plugins-list",
   "private": true,
   "version": "1.0.0",
-  "description": "Netlify plugins",
+  "description": "List of Netlify plugins",
+  "main": "site/plugins.json",
+  "files": [],
   "scripts": {
     "lint": "eslint 'functions/**/*.js'",
     "format": "prettier --write 'functions/**/*.js'",


### PR DESCRIPTION
See background at https://github.com/netlify/build/pull/2076#discussion_r532657394

This publish the `plugins.json` to npm under the package name `@netlify/plugins-list`.