### PR TITLE
Fix CORS with plugins.json

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   publish = "site"
   functions = "functions"
+
+[[headers]]
+  for = "/plugins.json"
+  [headers.values]
+  Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
CORS is failing when fetching `plugins.json` (see @nasivuela comment [here](https://github.com/netlify/netlify-react-ui/pull/6408#pullrequestreview-542738474)).

This PR aims at fixing this.