### PR TITLE
fix: remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "pacote": "^11.1.10",
     "prettier": "^2.0.5"
   },
-  "dependencies": {},
-  "engines": {
-    "node": ">=12"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
See https://github.com/netlify/cli/issues/1616.

@ehmicky do we need to enforce `engines` for this package?