### PR TITLE
Fix Node.js version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {},
   "engines": {
-    "node": ">=12"
+    "node": ">=8.3.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/1616

This npm package supports any Node.js version since it only exports a JSON file at the moment.
I made the Node.js version match the one in Netlify Build.