### PR TITLE
Update netlify-plugin-ghost-markdown to 3.0.3

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -106,11 +106,11 @@
   },
   {
     "author": "daviddarnes",
-    "description": "Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API.",
+    "description": "Generates posts, pages, tag pages and author pages from a Ghost publication as markdown files, using the Ghost Content API.",
     "name": "Ghost Markdown",
     "package": "netlify-plugin-ghost-markdown",
     "repo": "https://github.com/daviddarnes/netlify-plugin-ghost-markdown",
-    "version": "2.1.0"
+    "version": "3.0.3"
   },
   {
     "author": "netlify-labs",


### PR DESCRIPTION
- Adds tag page support, behind a flag
- Adds author page support, behind a flag
- Fixes bug where "null" images were found in the content but couldn't be replaced

---

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
https://app.netlify.com/sites/netlify-plugin-ghost-markdown-demo/deploys/5fd743754d5ec80e93395cf6