### PR TITLE
fix(plugin-applitools): update repo link and author

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -81,7 +81,7 @@
     "version": "1.0.3"
   },
   {
-    "author": "jlengstorf",
+    "author": "applitools",
     "description": "Require visual changes on production to be manually approved before going live!",
     "name": "Visual Diff (Applitools)",
     "package": "netlify-plugin-visual-diff",

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -85,7 +85,7 @@
     "description": "Require visual changes on production to be manually approved before going live!",
     "name": "Visual Diff (Applitools)",
     "package": "netlify-plugin-visual-diff",
-    "repo": "https://github.com/jlengstorf/netlify-plugin-visual-diff",
+    "repo": "https://github.com/applitools/netlify-plugin-visual-diff",
     "version": "1.2.0"
   },
   {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
No plugins changes - just the repo link and author update
