### PR TITLE
Add Jekyll Cache

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -422,5 +422,13 @@
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
     "version": "1.1.0"
+  },
+  {
+    "author": "mesomorphic",
+    "description": "Persist the Jekyll cache between Netlify builds",
+    "name": "Jekyll Cache",
+    "package": "netlify-plugin-jekyll-cache",
+    "repo": "https://github.com/Mesomorphic/netlify-plugin-jekyll-cache",
+    "version": "1.0.0"
   }
 ]

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -437,7 +437,7 @@
     "name": "Gmail",
     "package": "netlify-plugin-gmail",
     "repo": "https://github.com/racoonx2p/netlify-plugin-gmail",
-    "version": "1.1.0",
+    "version": "1.1.0"
   },
   {
     "author": "mesomorphic",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
First build: https://app.netlify.com/sites/matthewsimpson/deploys/60143c9e4b7b62048cbadf4a
Second build: https://app.netlify.com/sites/matthewsimpson/deploys/60143eb5a598010008f44965

The cache is stored in the first and restored in the second, which should improve Jekyll build times. It's probably less noticable on this site but I have other (private) sites that make use of image resizing that benefit greatly from this plugin (a 4m 30s build was reduced to 1m 15s).