### PR TITLE
chore: add `release-please`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+name: release-please
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
+          release-type: node
+          package-name: '@netlify/plugins-list'


### PR DESCRIPTION
This adds `release-please` since this repository is published as a npm package.

Ideally, we'd want those PRs to be automatically merged, but I'm not sure whether there is an easy way to do it (without adding an additional GitHub action or app).

Note: an admin will need to add the `NODE_PKG_RELEASE_TOKEN` secret to this repository on GitHub.