### PR TITLE
chore: fix tests timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
   },
   "engines": {
     "node": ">=8.3.0"
+  },
+  "ava": {
+    "timeout": "2m",
+    "verbose": true
   }
 }


### PR DESCRIPTION
This fixes tests timing out due to running many HTTP requests in parallel: https://github.com/netlify/plugins/runs/2042841869?check_suite_focus=true

Note: `got` itself does not [timeout by default](https://github.com/sindresorhus/got#timeout), so the timeout is only coming from Ava.