### PR TITLE
feat: update Cypress E2E plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -186,7 +186,7 @@
     "name": "Cypress",
     "package": "netlify-plugin-cypress",
     "repo": "https://github.com/cypress-io/netlify-plugin-cypress",
-    "version": "1.9.2"
+    "version": "2.1.0"
   },
   {
     "author": "cannikin",

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -186,7 +186,16 @@
     "name": "Cypress",
     "package": "netlify-plugin-cypress",
     "repo": "https://github.com/cypress-io/netlify-plugin-cypress",
-    "version": "2.1.0"
+    "version": "2.2.0",
+    "compatibility": [
+      {
+        "version": "2.2.0",
+        "migrationGuide": "https://github.com/cypress-io/netlify-plugin-cypress/releases/tag/v2.0.0"
+      },
+      {
+        "version": "1.11.1"
+      }
+    ]
   },
   {
     "author": "cannikin",


### PR DESCRIPTION
- run tests after deploy `onSuccess` by default
- running tests `preBuild` and `postBuild` is opt-in
- using bundled-in Chromium browser by default, it is more stable than Electron
- tested across our example projects, see links https://github.com/cypress-io/netlify-plugin-cypress/pull/133

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
