### PR TITLE
fix: update Next.js plugin compatibility to 1.1.2

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -430,7 +430,7 @@
     "version": "3.0.3",
     "compatibility": [
       {
-        "version": "1.1.1",
+        "version": "1.1.2",
         "siteDependencies": { "next": "<10.0.6" }
       }
     ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/erez-next-plugin-old/deploys/6050efb91a39b50007c8924a