### PR TITLE
chore: automate npm publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
         with:
           token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node
           package-name: '@netlify/plugins-list'
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,9 +35,4 @@ Netlify will try to reach the plugin author(s), and if that fails, we will add a
 
 Plugins are available to users as soon as the build of the Netlify site hosting `site/plugins.json` has completed. That build is triggered automatically each time a pull request is merged, and typically takes less than a minute.
 
-We still publish the list of plugins to npm to use it as a fallback in case that Netlify site is down. This is done with the following commands.
-
-```
-$ npm version major|minor|patch
-$ npm publish
-```
+We still publish the list of plugins to `npm` to use it as a fallback in case that Netlify site is down. To publish the list of plugins simply merge the release PR.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "site/plugins.json",
   "files": [],
   "scripts": {
+    "prepublishOnly": "npm ci && npm run lint && npm run format:ci && npm test",
     "lint": "eslint 'functions/**/*.js'",
     "format": "prettier --write 'functions/**/*.js'",
     "format:ci": "prettier --check 'functions/**/*.js'",


### PR DESCRIPTION
This PR automates the `npm publish` part of the release.