### PR TITLE
feat(sitemap): bump sitemap plugin to 0.8.0

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -102,7 +102,7 @@
     "name": "Sitemap",
     "package": "@netlify/plugin-sitemap",
     "repo": "https://github.com/netlify-labs/netlify-plugin-sitemap",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   {
     "author": "daviddarnes",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
The build: https://app.netlify.com/sites/monorepo-blog-1-yarn/deploys/605b79175695bc0008bfbf1b

And the actual sitemap produced containing the newly added feature in https://github.com/netlify-labs/netlify-plugin-sitemap/pull/70 - https://605b79175695bc0008bfbf1b--monorepo-blog-1-yarn.netlify.app/sitemap.xml - you can see the added prefix `/test-prefix`