### PR TITLE
fix(plugin-sitemap): update to version 0.8.1

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -102,7 +102,7 @@
     "name": "Sitemap",
     "package": "@netlify/plugin-sitemap",
     "repo": "https://github.com/netlify-labs/netlify-plugin-sitemap",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   {
     "author": "daviddarnes",


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-sitemap/issues/71

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/sitemap-plugin-test-site/deploys/606328dd7875ef00076150c0