### PR TITLE
chore: rename default branch from master to main

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@ Thanks for contributing the Netlify plugins directory!
 
 **Have you completed the following?**
 
-- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/master/docs/guidelines.md).
-- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/master/docs/CONTRIBUTING.md#required-fields) in your entry.
+- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
+- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
 - [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.
 
 **Test plan**

--- a/docs/plugin_review.md
+++ b/docs/plugin_review.md
@@ -89,8 +89,8 @@ This is a non-exhaustive list of common pitfalls
 
 ## Utilities
 
-- [ ] The [`cache` utility](https://github.com/netlify/build/blob/master/packages/cache-utils/README.md) should be used to cache files.
-- [ ] The [`git` utility](https://github.com/netlify/build/blob/master/packages/git-utils/README.md) should be used for git-related logic.
+- [ ] The [`cache` utility](https://github.com/netlify/build/blob/main/packages/cache-utils/README.md) should be used to cache files.
+- [ ] The [`git` utility](https://github.com/netlify/build/blob/main/packages/git-utils/README.md) should be used for git-related logic.
 
 ## Control flow
 


### PR DESCRIPTION
PR to make the necessary changes in order to rename the default branch from `master` to `main`.

### TODO:
- [x] Rename the branch on GitHub from `master` to `main`
- [x] Re-target the Netlify site to build production from `main`