### PR TITLE
Revert "chore: upgrade essential next.js to 3.2.0"

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -427,7 +427,7 @@
     "name": "Essential Next.js",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
-    "version": "3.2.0",
+    "version": "3.0.3",
     "compatibility": [
       {
         "version": "1.1.3",


### PR DESCRIPTION
This reverts the latest update of the Next.js plugin while the following bug is being looked at: https://github.com/netlify/netlify-plugin-nextjs/issues/254