### PR TITLE
feat: improve `compatibility` field validation

### DIFF
--- a/test/main.mjs
+++ b/test/main.mjs
@@ -10,7 +10,7 @@ import normalizeNodeVersion from 'normalize-node-version';
 import plugins from '../site/plugins.json';
 
 const { manifest } = pacote;
-const { valid: validVersion, validRange, lt: ltVersion } = semver;
+const { valid: validVersion, validRange, lt: ltVersion, major, minor, patch, minVersion } = semver;
 
 const STRING_ATTRIBUTES = ['author', 'description', 'name', 'package', 'repo', 'status', 'version'];
 const OPTIONAL_ATTRIBUTES = ['status', 'compatibility'];
@@ -20,6 +20,34 @@ const ENUMS = {
 };
 
 const COMPATIBILITY_ATTRIBUTES = ['version', 'migrationGuide', 'nodeVersion', 'siteDependencies'];
+
+// Compare two versions by their major versions.
+// Takes into account the special rules for `0.*.*` and `0.0.*` versions.
+// According to semver, the second number is the major release number for
+// `0.*.*` versions and the third for `0.0.*`. This is how `^` behaves with the
+// `semver` module which is used by `npm`.
+const isPreviousMajor = function (versionA, versionB) {
+  return ltVersion(getMajor(versionA), getMajor(versionB));
+};
+
+const getMajor = function (version) {
+  return minVersion(getMajorVersion(version)).version;
+};
+
+const getMajorVersion = function (version) {
+  const majorVersion = major(version);
+  if (majorVersion !== 0) {
+    return `${majorVersion}`;
+  }
+
+  const minorVersion = minor(version);
+  if (minorVersion !== 0) {
+    return `${majorVersion}.${minorVersion}`;
+  }
+
+  const patchVersion = patch(version);
+  return `${majorVersion}.${minorVersion}.${patchVersion}`;
+};
 
 plugins.forEach((plugin) => {
   const { package: packageName, repo, version, name, compatibility } = plugin;
@@ -72,13 +100,14 @@ plugins.forEach((plugin) => {
     return;
   }
 
-  test(`Plugin compatibility are sorted from highest to lowest version: ${packageName}`, (t) => {
+  test(`Plugin compatibility are sorted from highest to lowest version and with different major versions in each entry: ${packageName}`, (t) => {
     t.true(
       compatibility
         .filter((compatField) => validVersion(compatField.version) !== null)
         .every(
           (compatField, index) =>
-            index === compatibility.length - 1 || ltVersion(compatibility[index + 1].version, compatField.version),
+            index === compatibility.length - 1 ||
+            isPreviousMajor(compatibility[index + 1].version, compatField.version),
         ),
     );
   });


### PR DESCRIPTION
Fixes #298.

Due to the `compatibility` field being used for version pinning and due to the fact that version pinning is major-version-based, the current algorithm requires each `compatibility` entry to have a different major version.

We should validate this as part on our existing automated tests. 
Please note that, according to semver, the "major version" should be the second number for `0.*.*` versions and the third number for `0.0.*` versions.