### PR TITLE
Introducing the netlify stepzen plugin.

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -482,5 +482,13 @@
     "package": "netlify-plugin-ghost-inspector",
     "repo": "https://github.com/ghost-inspector/netlify-plugin",
     "version": "1.0.1"
+  },
+  {
+    "author": "Stepzen <team@stepzen.com>",
+    "description": "Deploy a [StepZen](http://stepzen.com) GraphQL API with any Netlify build",
+    "name": "Stepzen",
+    "package": "netlify-plugin-stepzen",
+    "repo": "https://github.com/steprz/netlify-plugin-stepzen",
+    "version": "1.0.0"
   }
 ]


### PR DESCRIPTION
    This commit adds the [Stepzen](https://stepzen.com) plugin
    to the netlify plugins directory.

    The plugin enables it's user to deploy a StepZen
    GraphQL API within any Netlify build.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
https://app.netlify.com/sites/jolly-clarke-e443a0/deploys?filter=main