### PR TITLE
feat: upgrade `netlify-plugin-html-validate` to `1.0.0`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -371,7 +371,12 @@
     "name": "HTML validate",
     "package": "netlify-plugin-html-validate",
     "repo": "https://github.com/oliverroick/netlify-plugin-html-validate",
-    "version": "0.1.1"
+    "version": "1.0.0",
+    "compatibility": [
+      {
+        "version": "0.1.1"
+      }
+    ]
   },
   {
     "author": "rozenmd",


### PR DESCRIPTION
This PR upgrades `netlify-plugin-html-validate` to `1.0.0`.

#233 is currently ongoing to do the same. I opened a separate PR to do some testing on the `compatibility` approach and make sure this works correctly.

With this PR, new sites installing that plugin in the UI or in `netlify.toml` will use `1.0.0`, but existing sites with that plugin will keep using `0.1.1`. Sites using this plugin with `package.json` will also keep using the same version.