### PR TITLE
fix: Fix Camel case. Stepzen --> StepZen

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -484,9 +484,9 @@
     "version": "1.0.1"
   },
   {
-    "author": "Stepzen <team@stepzen.com>",
+    "author": "StepZen <team@stepzen.com>",
     "description": "Deploy a StepZen (http://stepzen.com) GraphQL API with any Netlify build",
-    "name": "Stepzen",
+    "name": "StepZen",
     "package": "netlify-plugin-stepzen",
     "repo": "https://github.com/steprz/netlify-plugin-stepzen",
     "version": "1.0.1"


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
None needed. This is a cosmetic change. The name of the company is StepZen (not Stepzen). Sorry for the error.