### PR TITLE
feat: enforce that the first field in `compatibility` is the same as `version`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -360,6 +360,9 @@
     "version": "2.1.0",
     "compatibility": [
       {
+        "version": "2.1.0"
+      },
+      {
         "version": "1.4.3",
         "nodeVersion": "<12.13.0"
       }
@@ -374,8 +377,11 @@
     "version": "1.0.0",
     "compatibility": [
       {
-        "version": "0.1.1",
+        "version": "1.0.0",
         "migrationGuide": "https://github.com/oliverroick/netlify-plugin-html-validate/releases/tag/v1.0.0"
+      },
+      {
+        "version": "0.1.1"
       }
     ]
   },
@@ -435,6 +441,9 @@
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
     "version": "3.2.2",
     "compatibility": [
+      {
+        "version": "3.2.2"
+      },
       {
         "version": "1.1.5",
         "siteDependencies": { "next": "<10.0.6" }

--- a/test/main.mjs
+++ b/test/main.mjs
@@ -127,7 +127,12 @@ plugins.forEach((plugin) => {
 
       t.is(typeof version, 'string');
       t.not(validVersion(version), null);
-      t.true(ltVersion(compatVersion, version));
+
+      if (index === 0) {
+        t.is(compatVersion, version);
+      } else {
+        t.true(ltVersion(compatVersion, version));
+      }
 
       await t.notThrowsAsync(manifest(`${packageName}@${compatVersion}`));
     });


### PR DESCRIPTION
As part of https://github.com/netlify/build/issues/2788, we now need to enforce that the first entry in the `compatibility` entry is the same as the `version` field.

While this requires a little more work for plugin authors, this has many pros outlined in the issue above.

Note: this should only be merged after https://github.com/netlify/build/pull/2791 is merged.