### PR TITLE
feat: add documentation about breaking changes in plugins

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,7 +57,7 @@ As a way to encourage plugin users to upgrade, you can include a `migrationGuide
 ]
 ```
 
-When a new major release drops support for a specific Node.js version range, a `nodeVersion` field must be added to previous major releases.
+When a new major release drops support for a specific Node.js version range, you must add a `nodeVersion` field for previous major releases.
 
 ```json
 "version": "1.3.0"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ You can submit a PR to update the entry for a plugin that you maintain.
 
 The latest version of a Build Plugin must be specified in the `version` field in `plugins.json`. When updating a plugin, be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
 
-The `version` and `compatibility` fields are used to select the version of plugins installed from the [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation). This does not apply to plugins installed in the [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation).
+When a user installs a plugin from the  [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation), the `version` and `compatibility` fields are used to determine the plugin version that's installed. When a user installs a plugin in a [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation), they can specify a plugin version manually instead.
 
 ### Major releases
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,11 +19,65 @@ The following fields are required for all plugins included in the `plugins.json`
 - `name` - a human-readable [sentence cased](https://en.wikipedia.org/wiki/Letter_case#Sentence_case) version of the plugin title, for display purposes
 - `package` - the name of the published npm package
 - `repo` - the complete URL to the source repository for the plugin, on GitHub, GitLab, or Bitbucket. All source code must be public, and the repository must allow public issue submissions.
-- `version` - the exact version Netlify will use for all UI-installed instances of the plugin. To update the plugin version later, submit a new pull request to update this field.
+- `version` - the [latest version](#versioning) of the plugin.
 
 ## Update a plugin
 
-You can submit a PR to update the entry for a plugin that you maintain. If you update the plugin `version`, please be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
+You can submit a PR to update the entry for a plugin that you maintain.
+
+### Versioning
+
+The latest version of the plugin must be specified in the `version` field. When updating it, please be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
+
+The `version` and `compatibility` fields are used to select the version of plugins installed from the [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation). This does not apply to plugins installed in the [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation).
+
+### Major releases
+
+If a plugin has several major releases, the latest version of each major release must be specified in a `compatibility` array. The major releases must be sorted from most to least recent. The first `compatibility` item's `version` must be the same as the top-level `version` field.
+
+```json
+"version": "1.3.0"
+"compatibility": [
+  { "version": "1.3.0" },
+  { "version": "0.3.0" },
+  { "version": "0.2.0" }
+]
+```
+
+A `migrationGuide` URL pointing to a migration guide, a GitHub release or a list of breaking changes can be specified. This URL will be shown to users to encourage them to upgrade.
+
+```json
+"version": "1.0.0"
+"compatibility": [
+  {
+    "version": "1.0.0",
+    "migrationGuide": "https://github.com/oliverroick/netlify-plugin-html-validate/releases/tag/v1.0.0"
+  },
+  { "version": "0.1.1" }
+]
+```
+
+When a new major release drops support for a specific Node.js version range, a `nodeVersion` field must be added to previous major releases.
+
+```json
+"version": "1.3.0"
+"compatibility": [
+  { "version": "1.3.0" },
+  { "version": "0.3.0", "nodeVersion": "<12.0.0" },
+  { "version": "0.2.0", "nodeVersion": "<10.0.0" }
+]
+```
+
+A `siteDependencies` field must be added when dropping support for a specific version range of a Node module used by the plugin but installed in the site's `package.json` (not the plugin's `package.json`).
+
+```json
+"version": "1.3.0"
+"compatibility": [
+  { "version": "1.3.0" },
+  { "version": "0.3.0", "siteDependencies": { "next": "<11.0.0" } },
+  { "version": "0.2.0", "siteDependencies": { "next": "<10.0.6" } }
+]
+```
 
 ## Request deactivation
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,7 @@ If a plugin has several major releases, the latest version of each major release
 ]
 ```
 
-A `migrationGuide` URL pointing to a migration guide, a GitHub release or a list of breaking changes can be specified. This URL will be shown to users to encourage them to upgrade.
+As a way to encourage plugin users to upgrade, you can include a `migrationGuide` URL that refers plugin users to a migration guide, GitHub release, or a list of breaking changes.
 
 ```json
 "version": "1.0.0"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,7 +68,7 @@ When a new major release drops support for a specific Node.js version range, a `
 ]
 ```
 
-A `siteDependencies` field must be added when dropping support for a specific version range of a Node module used by the plugin but installed in the site's `package.json` (not the plugin's `package.json`).
+When a new major release drops support for a specific version range of a Node.js module used by the plugin but installed in the site's `package.json` (not the plugin's `package.json`), you must add a `siteDependencies` field.
 
 ```json
 "version": "1.3.0"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When a user installs a plugin from the  [Netlify plugins directory](https://docs
 
 ### Major releases
 
-If a plugin has several major releases, the latest version of each major release must be specified in a `compatibility` array. The major releases must be sorted from most to least recent. The first `compatibility` item's `version` must be the same as the top-level `version` field.
+If a plugin has several major releases, you must specify the latest version of each major release in a `compatibility` array with major releases sorted from most recent to least recent. The first `compatibility` item's `version` should be the same as the top-level `version` field.
 
 ```json
 "version": "1.3.0"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ You can submit a PR to update the entry for a plugin that you maintain.
 
 The latest version of a Build Plugin must be specified in the `version` field in `plugins.json`. When updating a plugin, be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
 
-When a user installs a plugin from the  [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation), the `version` and `compatibility` fields are used to determine the plugin version that's installed. When a user installs a plugin in a [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation), they can specify a plugin version manually instead.
+When a user installs a plugin from the [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation), the `version` and `compatibility` fields are used to determine the plugin version that's installed. When a user installs a plugin in a [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation), they can specify a plugin version manually instead.
 
 ### Major releases
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,7 @@ You can submit a PR to update the entry for a plugin that you maintain.
 
 ### Versioning
 
-The latest version of the plugin must be specified in the `version` field. When updating it, please be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
+The latest version of a Build Plugin must be specified in the `version` field in `plugins.json`. When updating a plugin, be sure to test the new version [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin) before submitting.
 
 The `version` and `compatibility` fields are used to select the version of plugins installed from the [Netlify plugins directory](https://docs.netlify.com/configure-builds/build-plugins/#ui-installation). This does not apply to plugins installed in the [site's `package.json`](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation).
 

--- a/docs/plugin_review.md
+++ b/docs/plugin_review.md
@@ -40,8 +40,14 @@ This is a non-exhaustive list of common pitfalls
 - [ ] The plugin's purpose must be in the best interest of Netlify and its users.
 - [ ] The functionality must not be already provided by Netlify or another well-maintained plugin.
 - [ ] The code [must be open source](guidelines.md#keep-it-open).
-- [ ] Breaking changes are not allowed at the moment.
 - [ ] The plugin should work [without any configuration](guidelines.md#provide-a-zero-config-default). Exceptions can be made when there is no way around it, such as for an API token. In that case, environment variables should be used instead of `inputs`.
+
+### Versioning
+
+- [ ] Breaking changes require a new major release number.
+- [ ] Each major release must be specified in the [`compatibility` array](CONTRIBUTING.md#major-releases).
+- [ ] When dropping a Node.js version, the [`nodeVersion` field should be added to previous major releases](CONTRIBUTING.md#major-releases).
+- [ ] When dropping a site dependency's version, the [`siteDependencies` field should be added to previous major releases](CONTRIBUTING.md#major-releases).
 
 ### Documentation
 


### PR DESCRIPTION
Fixes #236.

This adds some documentation about breaking changes in plugins.

Some implementation details are purposely omitted to only focus on the plugin author experience when updating a plugin.