### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '*'
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,16 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node-version: [15.x]
-      fail-fast: false
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Node.js ${{ matrix.node-version }}
+      - name: Using Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '*'
+          check-latest: true
       - name: Install dependencies
         run: npm ci
       - name: Linting


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.