### PR TITLE
fix(plugin-hugo-cache-resources): log the actual cached file count

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -350,7 +350,7 @@
     "name": "Hugo cache resources",
     "package": "netlify-plugin-hugo-cache-resources",
     "repo": "https://github.com/cdeleeuwe/netlify-plugin-hugo-cache-resources",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   {
     "author": "cdeleeuwe",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

https://app.netlify.com/sites/netlify-plugin-hugo-cache-resources/deploys/60a66dcae06bd40007ea138e

Minor fix to log the actual cached file count.
