### PR TITLE
fix: Update version netlify-plugin-stepzen

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -513,7 +513,7 @@
     "name": "StepZen",
     "package": "netlify-plugin-stepzen",
     "repo": "https://github.com/steprz/netlify-plugin-stepzen",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   {
     "author": "bharathvaj-ganesan",


### PR DESCRIPTION
The netlify plugin for Stepzen failed in some situations
because of a Node.js version dependency that was too recent.

This has been fixed in the latest version of the plugin.

This pull request updates the directory to use the latest version.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

This uses v1.0.2 plugin installed locally.

https://app.netlify.com/sites/jolly-clarke-e443a0/deploys/60a803f3f68da013509adfe4

