### PR TITLE
chore: revert essential next to 3.4.2

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -457,10 +457,10 @@
     "name": "Essential Next.js",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
-    "version": "3.5.0",
+    "version": "3.4.2",
     "compatibility": [
       {
-        "version": "3.5.0"
+        "version": "3.4.2"
       },
       {
         "version": "1.1.5",


### PR DESCRIPTION
I am reverting the latest update because there have been some bugsnag events I'd liek to investigate, but it's late here

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
