### PR TITLE
feat: version `plugins.json`

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,21 @@
+name: versioning
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      # Updates the v* branch to reflect the content of the main branch
+      # This allows versioning `plugins.json`, providing consumers use the
+      # branch-specific deploy URL like
+      #   v*--netlify-plugins.netlify.app/plugins.json
+      - name: Update branch
+        run: |
+          git branch -C main v1
+          git push -u origin v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of https://github.com/netlify/pod-workflow/issues/157

This PR adds versioning to `plugins.json`, based on @verythorough's [great idea](https://github.com/netlify/pod-workflow/issues/157#issuecomment-785201050).

Each time a new commit is pushed to `main`, a GitHub action updates the `v1` git branch so it points to `main` latest commit.
When a breaking change of `plugins.json` is made, we should change `v1` to `v2` in that GitHub action, and so on.

Consumers should then access `plugins.json` using https://v1--netlify-plugins.netlify.app/plugins.json instead of https://netlify-plugins.netlify.app/plugins.json