### PR TITLE
feat: fix `plugins.json` versioning

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       # Updates the v* branch to reflect the content of the main branch
       # This allows versioning `plugins.json`, providing consumers use the
       # branch-specific deploy URL like


### PR DESCRIPTION
This fixes the GitHub action updating the `v1` branch, which [is currently failing](https://github.com/netlify/plugins/runs/3193749187?check_suite_focus=true)