### PR TITLE
chore: bump `plugins.json` to v2

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -22,7 +22,7 @@ jobs:
       #    is a contents breaking change (v* tag + GitHub release + npm release)
       - name: Update branch
         run: |
-          git tag --force list-v1
+          git tag --force list-v2
           git push --force --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,9 +2,9 @@
 
 ## Deploying `plugins.json`
 
-Each new commit pushed to the `main` branch is deployed to [https://list-v1--netlify-plugins.netlify.app/plugins.json](https://list-v1--netlify-plugins.netlify.app/plugins.json) thanks to [this repository's Netlify site](https://app.netlify.com/sites/netlify-plugins/deploys).
+Each new commit pushed to the `main` branch is deployed to [https://list-v2--netlify-plugins.netlify.app/plugins.json](https://list-v2--netlify-plugins.netlify.app/plugins.json) thanks to [this repository's Netlify site](https://app.netlify.com/sites/netlify-plugins/deploys).
 
-This is done in a branch deploy triggered by updating the `list-v1` git tag to reference each new commit on the `main` branch. This is performed automatically by a [GitHub action](/.github/workflows/versioning.yml).
+This is done in a branch deploy triggered by updating the `list-v2` git tag to reference each new commit on the `main` branch. This is performed automatically by a [GitHub action](/.github/workflows/versioning.yml).
 
 That URL is fetched by:
 
@@ -25,8 +25,7 @@ This section explains how the `plugins.json`'s syntax is versioned. This relates
 To introduce a breaking change to the syntax of `plugins.json`:
 
 - Update `plugins.json` with that breaking change.
-- Increment every reference of `list-v1` in this repository (including this file).
-- Make a new commit to `main`.
+- Increment every reference of `list-v2` in this repository (including this file).
 - Wait for the new versioned URL to be built and ensure it can be accessed and looks normal.
 - Update the URL in Netlify Build, CLI and App.
 


### PR DESCRIPTION
Fixes #260.

Before `@netlify/build@17.4.0` ([PR](https://github.com/netlify/build/pull/3361)), adding new properties to the `compatibility` field in `plugins.json` would crash. `@netlify/build@17.4.0` was added to `netlify-cli@5.4.1`. 

In order to add new properties to the `compability` field, this PR bumps the `plugins.json` format version from v1 to v2.
Versions older than `@netlify/build@17.4.0` and `netlify-cli@5.4.1` use either https://netlify-plugins.netlify.app/plugins.json or https://list-v1--netlify-plugins.netlify.app/plugins.json. Since bumping to v2 will freeze the contents of https://list-v1--netlify-plugins.netlify.app/plugins.json, those older versions will keep working.

In other words, the only difference between v1 and v2 is that it adds a new requirement for consumers: they should not fail on unknown properties in the `compatibility` field.

We will then need to update the URL in Netlify Build, CLI and front-end app to https://list-v2--netlify-plugins.netlify.app/plugins.json so they get the latest `plugins.json` changes.

https://list-v2--netlify-plugins.netlify.app/plugins.json will be automatically created/deployed by merging this PR to `main`.