### PR TITLE
feat: add `netlify-plugin-use-env-in-runtime`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -554,6 +554,6 @@
     "name": "Use Env in Runtime",
     "package": "netlify-plugin-use-env-in-runtime",
     "repo": "https://github.com/ARKHN3B/netlify-plugin-use-env-in-runtime",
-    "version": "1.1.0"
+    "version": "1.2.1"
   }
 ]

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -547,5 +547,13 @@
     "package": "netlify-plugin-cecil-cache",
     "repo": "https://github.com/Cecilapp/netlify-plugin-cecil-cache",
     "version": "0.2.5"
+  },
+  {
+    "author": "Ben Lmsc",
+    "description": "Make some environment variables available only at build time in the runtime of your application.",
+    "name": "Use Env in Runtime",
+    "package": "netlify-plugin-use-env-in-runtime",
+    "repo": "https://github.com/ARKHN3B/netlify-plugin-use-env-in-runtime",
+    "version": "1.1.0"
   }
 ]


### PR DESCRIPTION
Description:

This plugin allows you to transfer environment variables in the runtime of your application from those declared in your netlify.toml file and which are only executed at build time.

You can even override variables defined in the Netlify UI!

---

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

For test plan, see: [https://app.netlify.com/sites/use-env-in-runtime-plugin-demo/deploys/6106f295e858e60008be2c41](https://app.netlify.com/sites/use-env-in-runtime-plugin-demo/deploys/6106f295e858e60008be2c41)
