### PR TITLE
chore!: expose `pluginsUrl`

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -25,7 +25,8 @@ This section explains how the `plugins.json`'s syntax is versioned. This relates
 To introduce a breaking change to the syntax of `plugins.json`:
 
 - Update `plugins.json` with that breaking change.
-- Increment every reference of `list-v2` in this repository (including this file).
+- Increment every reference of `list-v2` in this repository, including this file and the `pluginsUrl` returned property.
+- Ensure the PR is marked with `!` so that `release-please` makes a major release of the `@netlify/plugins-list` npm package.
 - Wait for the new versioned URL to be built and ensure it can be accessed and looks normal.
 - Update the URL in Netlify Build, CLI and App.
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const pluginsList = require('./site/plugins.json');
+
+const pluginsUrl = 'https://list-v2--netlify-plugins.netlify.app/plugins.json';
+
+module.exports = { pluginsList, pluginsUrl };

--- a/test/main.mjs
+++ b/test/main.mjs
@@ -7,7 +7,7 @@ import { upperCaseFirst } from 'upper-case-first';
 import isPlainObj from 'is-plain-obj';
 import semver from 'semver';
 import normalizeNodeVersion from 'normalize-node-version';
-import plugins from '../site/plugins.json';
+import { pluginsList, pluginsUrl } from '../index.js';
 
 const { manifest } = pacote;
 const { valid: validVersion, validRange, lt: ltVersion, major, minor, patch, minVersion } = semver;
@@ -49,7 +49,7 @@ const getMajorVersion = function (version) {
   return `${majorVersion}.${minorVersion}.${patchVersion}`;
 };
 
-plugins.forEach((plugin) => {
+pluginsList.forEach((plugin) => {
   const { package: packageName, repo, version, name, compatibility } = plugin;
 
   Object.entries(plugin).forEach(([attribute, value]) => {
@@ -174,4 +174,8 @@ plugins.forEach((plugin) => {
       );
     });
   });
+});
+
+test('Plugins URL exists', (t) => {
+  t.true(pluginsUrl.startsWith('https://'));
 });


### PR DESCRIPTION
Implements @erezrokah feedback at https://github.com/netlify/plugins/pull/402#issuecomment-890860409

This exposes a `pluginsUrl` property to allow consumers to use npm versioning instead of updating the URL to version the `plugins.json` syntax. This only works if the consumer uses the npm package, not if the URL is fetched directly.

To avoid breaking consumers, this means any `plugins.json` breaking change will now also be a npm package breaking change.

This changes the npm package's return value, so this PR is a breaking change.