### PR TITLE
fix: deprecate the old Gatsby cache plugin in description

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -66,7 +66,7 @@
   },
   {
     "author": "jlengstorf",
-    "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️",
+    "description": "This plugin is deprecated. Please install the Essential Gatsby plugin instead",
     "name": "Gatsby cache",
     "package": "netlify-plugin-gatsby-cache",
     "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
