### PR TITLE
feat: add `3.9.0` (feature flagged) to Essential Next.js plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -460,6 +460,10 @@
     "version": "3.8.0",
     "compatibility": [
       {
+        "version": "3.9.0",
+        "featureFlag": "plugin_nextjs_example"
+      },
+      {
         "version": "3.8.0"
       },
       {


### PR DESCRIPTION
Note: this PR is intended only for today's company demo, and will be closed after the demo. Please do not merge.

This adds a new version for the Essential Next.js plugin, feature flagged.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Manual testing.