### PR TITLE
bug: patch fossa install process

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - main
+      - master
       - chore/fossa-workflow
 
 defaults:


### PR DESCRIPTION
NOTICE: If this pull request does not apply to your repository, feel free to close this pull request. This is a generated pull request by [github-tools](https://github.com/netlify/github-tools/) to fix Fossa License Scanning if it exists on this Repository.