### PR TITLE
fix: corner case causing build internal error.

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -533,12 +533,12 @@
     "version": "1.0.1"
   },
   {
-    "author": "StepZen <team@stepzen.com>",
+    "author": "StepZen <stepzen-team@stepzen.com>",
     "description": "Deploy a StepZen (http://stepzen.com) GraphQL API with any Netlify build",
     "name": "StepZen",
     "package": "netlify-plugin-stepzen",
     "repo": "https://github.com/steprz/netlify-plugin-stepzen",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   {
     "author": "bharathvaj-ganesan",


### PR DESCRIPTION
Patch release 1.0.3 of the StepZen plugin unbreaks
a corner case where a misconfigured plugin environment
would could cause the build to fail rather than output
a helpful error message.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

See: steprz/netlify-plugin-stepzen#17
