### PR TITLE
fix: deactivate `netlify-plugin-search-index`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -170,7 +170,8 @@
     "name": "Search index",
     "package": "netlify-plugin-search-index",
     "repo": "https://github.com/sw-yx/netlify-plugin-search-index",
-    "version": "0.1.5"
+    "version": "0.1.5",
+    "status": "DEACTIVATED"
   },
   {
     "author": "sw-yx",


### PR DESCRIPTION
Fixes https://github.com/netlify/pod-workflow/issues/294

[`netlify-plugin-search-index`](https://github.com/sw-yx/netlify-plugin-search-index) is using `zip-it-and-ship-it` directly which is creating some bugs and maintenance issues as outlined in https://github.com/netlify/pod-workflow/issues/294.

We've reached out in https://github.com/sw-yx/netlify-plugin-search-index/issues/31. However, the plugin does not [appear to be maintained anymore](https://github.com/sw-yx/netlify-plugin-search-index#future-plans). Following [our guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md#be-prepared-to-provide-support), this PR deactivates this plugin until this bug is fixed. 

Deactivating this plugin will hide it from the UI directory. Users will still be able to install it using `package.json`. Current UI users will see be able to use this plugin if already installed.