### PR TITLE
chore!: drop Node 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "upper-case-first": "^2.0.2"
       },
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.18.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "upper-case-first": "^2.0.2"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=10.18.0"
   },
   "ava": {
     "timeout": "2m",


### PR DESCRIPTION
This drops Node 8 support now that all consumers (Netlify CLI and Netlify Build) have dropped it.