### PR TITLE
chore: updating CoC

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -38,7 +38,7 @@ All plugin source code must be public and generally human-readable. Plugin users
 
 ## Understand required agreements.
 
-When you publish a plugin to the npm Public Registry, you agree to npm's [Open Source Terms](https://www.npmjs.com/policies/open-source-terms). When you use a plugin on Netlify, you agree to Netlify's [Terms of Use Agreement](https://www.netlify.com/legal/terms-of-use/). When you make that plugin available to other Netlify users, you agree to interact with those users in accordance with the [Netlify Community Code of Conduct](https://community-docs.netlify.com/code-of-conduct.html).
+When you publish a plugin to the npm Public Registry, you agree to npm's [Open Source Terms](https://www.npmjs.com/policies/open-source-terms). When you use a plugin on Netlify, you agree to Netlify's [Terms of Use Agreement](https://www.netlify.com/legal/terms-of-use/). When you make that plugin available to other Netlify users, you agree to interact with those users in accordance with the [Netlify Forums Code of Conduct](https://forums-docs.netlify.app/code-of-conduct.html).
 
 In general, this means that you agree to be kind, to be honest, and to not do anything illegal, but you should read these documents to know exactly what they mean in detail.
 


### PR DESCRIPTION

just updating a link in documentation
community-docs.netlify.com does not exist anymore, and we have moved over to forums

This should be non-impacting change