### PR TITLE
fix: main file is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "exports": "./index.js",
   "main": "./index.js",
   "files": [
+    "index.js",
     "site/plugins.json"
   ],
   "scripts": {


### PR DESCRIPTION
The [main file is missing from the npm package](https://app.renovatebot.com/package-diff?name=@netlify%2fplugins-list&from=5.0.0&to=6.0.0) since https://github.com/netlify/plugins/pull/506

Thankfully, this was a major release, so this did not break programmatic consumers.
Our front-end is using the URL published by this repository's Netlify site, so it did not break it either. 
However, we should patch this.

The reason is: the `files` property in `package.json` usually includes the `main` property by default. However, it seems like this does not work when the `main` property starts with a dot. :man_shrugging: 
On the other hand, the `exports` property _must_ start with a dot, which I why I changed the `main` property so they are equal to each other. But that change broke the `files` property.