### PR TITLE
fix: bump `netlify-plugin-debug-cache` to `1.0.4`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -127,7 +127,7 @@
     "name": "Debug cache",
     "package": "netlify-plugin-debug-cache",
     "repo": "https://github.com/netlify-labs/netlify-plugin-debug-cache",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   {
     "author": "shortdiv",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

This adds a bug fix: https://github.com/netlify-labs/netlify-plugin-debug-cache/pull/12#event-5931062887

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Manual testing.