### PR TITLE
fix: upgrade netlify-plugin-commandbar version to `0.0.4`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -636,6 +636,6 @@
     "name": "CommandBar",
     "package": "@commandbar/netlify-plugin-commandbar",
     "repo": "https://github.com/tryfoobar/netlify-plugin-commandbar",
-    "version": "0.0.3"
+    "version": "0.0.4"
   }
 ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

Fixes a parsing bug found here: https://github.com/tryfoobar/netlify-plugin-commandbar/pull/7