### PR TITLE
fix(plugins): update Algolia crawler

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -469,7 +469,7 @@
     "name": "Algolia crawler",
     "package": "@algolia/netlify-plugin-crawler",
     "repo": "https://github.com/algolia/algoliasearch-netlify",
-    "version": "1.0.0"
+    "version": "1.0.14"
   },
   {
     "author": "netlify",


### PR DESCRIPTION
I had the impression that `plugins.json` was deprecated so we did not bothered to update it. 
No breaking changes here, mostly dependencies upgrade.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.




