### PR TITLE
Revert Algolia crawler latest update

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -469,7 +469,7 @@
     "name": "Algolia crawler",
     "package": "@algolia/netlify-plugin-crawler",
     "repo": "https://github.com/algolia/algoliasearch-netlify",
-    "version": "1.0.14"
+    "version": "1.0.0"
   },
   {
     "author": "netlify",


### PR DESCRIPTION
This reverts commit 41408b8c2962ad034e98c5117c7d5ae3a66bbfa4.

The last update of the Algolia crawler plugin fails due to what seems to be a bug in our TypeScript setup.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Not needed.