### PR TITLE
feat: update version of @sentry/netlify-build-plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -314,7 +314,7 @@
     "name": "Sentry",
     "package": "@sentry/netlify-build-plugin",
     "repo": "https://github.com/getsentry/sentry-netlify-build-plugin",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   {
     "author": "AshikNesin",


### PR DESCRIPTION
**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Tested a deploy with a local instance of sentry and the deploy went just fine. My local version of the plugin was 1.1.1.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/35509934/155399898-602efc5a-5eb2-4d3c-9d08-d92e692f4dd7.png">

<img width="855" alt="image" src="https://user-images.githubusercontent.com/35509934/155399850-d077485e-e834-4ef3-a97e-368abca18178.png">

