### PR TITLE
fix: upgrade netlify-plugin-stepzen version to 1.0.4

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -580,7 +580,7 @@
     "name": "StepZen",
     "package": "netlify-plugin-stepzen",
     "repo": "https://github.com/steprz/netlify-plugin-stepzen",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   {
     "author": "bharathvaj-ganesan",


### PR DESCRIPTION
A roll-up of dependency updates.
More info at https://github.com/steprz/netlify-plugin-stepzen/releases/tag/v1.0.4

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
https://app.netlify.com/sites/romantic-khorana-08bd2e/deploys/622731c696238a0008387741