### PR TITLE
chore: updating netlify-plugin-cloudinary to 1.0.3

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -644,6 +644,6 @@
     "name": "Cloudinary",
     "package": "netlify-plugin-cloudinary",
     "repo": "https://github.com/colbyfayock/netlify-plugin-cloudinary",
-    "version": "1.0.0"
+    "version": "1.0.3"
   }
 ]


### PR DESCRIPTION
**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Resolves the following issues:
- https://github.com/colbyfayock/netlify-plugin-cloudinary/issues/14
- https://github.com/colbyfayock/netlify-plugin-cloudinary/issues/15

Misc fixes / updates:
- Improved logging
- Adds warning for no images found in output (likely not configured the right path)
- Fixes bug where the `imagesPath` input wasn't being used
- Realized image output wouldn't be available prebuild 🤦‍♀️ which prevented uploads from working properly, moved this into build


Deploy with default settings: https://app.netlify.com/sites/glittery-cheesecake-01e8b9/deploys/623a1dde3cd3960008540958

Deploy with "upload" delivery type: https://app.netlify.com/sites/glittery-cheesecake-01e8b9/deploys/623a1e4c40ee67000876821c
