### PR TITLE
fix: downgrade Next to 4.2.8

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -477,10 +477,10 @@
     "name": "Essential Next.js",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
-    "version": "4.3.1",
+    "version": "4.2.8",
     "compatibility": [
       {
-        "version": "4.3.1",
+        "version": "4.2.8",
         "migrationGuide": "https://ntl.fyi/next-plugin-migration"
       },
       {


### PR DESCRIPTION
This temporarily downgrades the auto-installed version of the Next.js plugin because of https://github.com/netlify/netlify-plugin-nextjs/issues/1287

The plugin version itself seems fine, but auto-installing it causes OOM errors. 