### PR TITLE
fix: deactivate the deprecated Gatsby Cache plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -70,7 +70,8 @@
     "name": "Gatsby cache",
     "package": "netlify-plugin-gatsby-cache",
     "repo": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache",
-    "version": "0.3.0"
+    "version": "0.3.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "edm00se",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] (N/A) Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Test not needed.

This plugin was deprecated last year, and a deprecation message was added to the plugin description (https://github.com/netlify/plugins/pull/415). However, by deactivating the plugin, we can remove it from the directory for new installs. This will not remove the plugin from sites where it's already installed, and the plugin listing will still show in the list of installed plugins in the site admin UI.

Let me know if there's some reason why we shouldn't deactivate this!