### PR TITLE
fix: rollback to earlier version of Gatsby plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -503,10 +503,10 @@
     "name": "Essential Gatsby",
     "package": "@netlify/plugin-gatsby",
     "repo": "https://github.com/netlify/netlify-plugin-gatsby",
-    "version": "3.2.0",
+    "version": "3.1.0",
     "compatibility": [
       {
-        "version": "3.2.0",
+        "version": "3.1.0",
         "migrationGuide": "https://ntl.fyi/gatsby-plugin-migration"
       },
       {


### PR DESCRIPTION
Rolling back due to missing polyfill

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin
