### PR TITLE
feat: upgrade netlify-plugin-submit-sitemap to 0.4.0

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -383,11 +383,11 @@
   },
   {
     "author": "cdeleeuwe",
-    "description": "Automatically submit your sitemap to Google, Bing, and Yandex after every production build!",
+    "description": "Automatically submit your sitemap to Google and Yandex after every production build!",
     "name": "Submit sitemap",
     "package": "netlify-plugin-submit-sitemap",
     "repo": "https://github.com/cdeleeuwe/netlify-plugin-submit-sitemap",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   {
     "author": "netlify-labs",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
https://app.netlify.com/sites/netlify-plugin-submit-sitemap/deploys/62a4222d7acaf50008a71d48

Removed submitting sitemap to Bing since it has been deprecated. See https://blogs.bing.com/webmaster/may-2022/Spring-cleaning-Removed-Bing-anonymous-sitemap-submission
