### PR TITLE
fix: deprecate old Next.js plugins

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -108,11 +108,12 @@
   },
   {
     "author": "pizzafox",
-    "description": "Cache the .next build folder between builds",
+    "description": "This plugin is deprecated. The functionality is now built in",
     "name": "Next.js cache",
     "package": "netlify-plugin-cache-nextjs",
     "repo": "https://github.com/pizzafox/netlify-cache-nextjs",
-    "version": "1.4.0"
+    "version": "1.4.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "netlify-labs",
@@ -446,11 +447,12 @@
   },
   {
     "author": "rayriffy",
-    "description": "Netlify plugin that allows you to deploy dynamic NextJS path statically",
+    "description": "This plugin is deprecated. The functionality is now built in",
     "name": "Next dynamic routes",
     "package": "netlify-plugin-next-dynamic",
     "repo": "https://github.com/Brikl/opensource/tree/master/libs/netlify-plugin-next-dynamic",
-    "version": "1.0.9"
+    "version": "1.0.9",
+    "status": "DEACTIVATED"
   },
   {
     "author": "ample",


### PR DESCRIPTION
Deprecates two Next.js plugins which are not needed and conflict with the official plugin


**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
