### PR TITLE
feat: add feature flagged version of Next runtime

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -489,11 +489,15 @@
   {
     "author": "netlify",
     "description": "Build and deploy Next.js applications with server-side rendering. No extra configuration required.",
-    "name": "Essential Next.js",
+    "name": "Next.js Runtime",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/netlify-plugin-nextjs",
     "version": "4.14.2",
     "compatibility": [
+      {
+        "version": "4.17.1-runtime.7",
+        "featureFlag": "build_plugins_use_prerelease"
+      },
       {
         "version": "4.14.2",
         "migrationGuide": "https://ntl.fyi/next-plugin-migration"


### PR DESCRIPTION
This PR adds a prerelease version behind the feature flag `build_plugins_use_prerelease`. It also changes the name to "Next.js Runtime"

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
