### PR TITLE
feat: add `netlify-plugin-playwright-cache`

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -676,5 +676,13 @@
     "package": "@takeshape/netlify-plugin-takeshape",
     "repo": "https://github.com/takeshape/netlify-plugin-takeshape",
     "version": "1.0.0"
+  },
+  {
+    "author": "Hung Viet Nguyen",
+    "description": "Persist the Playwright executables between Netlify builds.",
+    "name": "Playwright cache",
+    "package": "netlify-plugin-playwright-cache",
+    "repo": "https://github.com/nvh95/netlify-plugin-playwright-cache",
+    "version": "0.0.1"
   }
 ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [x] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**TEST PLAN**

**Why `netlify-plugin-playwright-cache`**
When you install `playwright-chromium`, it downloads Chromium executables to a cache folder (not `node_modules`). Netlify does not cache this folder between builds, but caches `node_modules`. This leads to unsuccessful builds with the following error like this:

```
11:33:48 PM: [: Executable doesn't exist at /opt/buildhome/.cache/ms-playwright/chromium-1019/chrome-linux/chrome
╔═════════════════════════════════════════════════════════════════════════╗
11:33:48 PM: ║ Looks like Playwright Test or Playwright was just installed or updated. ║
11:33:48 PM: ║ Please run the following command to download new browsers:              ║
11:33:48 PM: ║                                                                         ║
11:33:48 PM: ║     npx playwright install                                              ║
11:33:48 PM: ║                                                                         ║
11:33:48 PM: ║ <3 Playwright Team                                                      ║
11:33:48 PM: ╚═════════════════════════════════════════════════════════════════════════╝
```

This plugins fixes the above issue by caching the Playwright executables (Chromium, ffmpeg...) between builds.

**Reproduction**

Deploy this commit https://github.com/nvh95/slidev-example/commit/b89241d450b41c27093c9d07c89a2e0ab0a7f681 on Netlify. It will succeed the first time, then fail in the second time (since Playwright Chromium executables are missing)

**Logs**
- Unsuccessful deploy without `netlify-plugin-playwright-cache`: https://app.netlify.com/sites/wondrous-lebkuchen-7d20d6/deploys/6318c028783760172e546320
- Successful deploy with `netlify-plugin-playwright-cache`: https://app.netlify.com/sites/wondrous-lebkuchen-7d20d6/deploys/6318d1d11e55f60009ea676f
