### PR TITLE
chore: stub of GitHub action and script to sync CMS to plugins repo

### DIFF
--- a/.github/workflows/sync-cms-to-repo.yml
+++ b/.github/workflows/sync-cms-to-repo.yml
@@ -1,0 +1,22 @@
+name: Sync CMS to Plugins Repository
+on: [repository_dispatch]
+jobs:
+  sync-to-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Using Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '*'
+          cache: 'npm'
+          check-latest: true
+      - name: Install dependencies
+        run: npm install
+      - name: Sync CMS to repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CMS_CHANGES: ${{ toJson(github.event.client_payload) }}
+
+        run: node bin/sync_cms_to_plugins_repo.js

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 /build
 .vscode
 .DS_Store
+.env
 
 # Local Netlify folder
 .netlify

--- a/bin/sync_cms_to_plugins_repo.js
+++ b/bin/sync_cms_to_plugins_repo.js
@@ -1,0 +1,11 @@
+// eslint-disable-next-line n/prefer-global/process
+const changes = JSON.parse(process.env.CMS_CHANGES)
+
+console.log('Checking for CMS updates...')
+
+// This will be replaced in a follow up PR  with the actual sync logic
+if (changes && Object.keys(changes).length !== 0) {
+  console.log('Synchronizing changes to plugins repo...')
+}
+
+console.log('Done synching CMS updates to plugins repo.')


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

## Description

Adds the stub of a GitHub action and script to sync CMS changes to the plugins repository. This is required so that I can ensure the dispatch of the action is working when the CMS Webhook runs.

A follow up PR will have the actual sync implemented.

Relates to:
- #820
- https://github.com/netlify/pod-ecosystem-frameworks/issues/223

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [ ] Updating a plugin
- [x] Automation

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.

N/A

![Character from Lord of the Rings saying, "So it begins"](https://media.giphy.com/media/3P0oEX5oTmrkY/giphy.gif)