### PR TITLE
feat: add netlify-plugin-formspree

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -697,5 +697,13 @@
     "repo": "https://github.com/netlify/plugins",
     "version": "0.1.2",
     "status": "DEACTIVATED"
-  }
+  },
+  {
+    "author": "Formspree",
+    "description": "Automaticly deploy forms to Formspree via the Formspree CLI",
+    "name": "Deploy to Formspree",
+    "package": "netlify-plugin-formspree",
+    "repo": "https://github.com/formspree/netlify-plugin-formspree",
+    "version": "0.0.3"
+  }  
 ]


### PR DESCRIPTION
A Netlify plugin for Formspree!

See https://github.com/formspree/netlify-plugin-formspree

**Are you adding a plugin or updating one?**

- [X] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [X] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [X] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [X] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Public deploy log: 

https://app.netlify.com/sites/formspree-example-netlify-plugin/deploys/633b377263c4ac24dcf06d98

This plugin just installs [formspree-cli](https://github.com/formspree/formspree-cli) and runs `formspree deploy`. The Formspree CLI can be tested by cloning it and running `npm run test`.  

