### PR TITLE
fix: corrected sync issue from CMS that included _key in compatibility array items

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -203,7 +203,16 @@ const stripNullifiedFields = (plugin) => {
  * return {BuildPluginEntity[]} The updated list of plugins
  */
 export const updatePlugins = (changes, plugins) => {
-  const pluginChanges = convertCmsChangesToRepoPlugin(changes)
+  const { compatibility, ...restOfChanges } = changes
+  const updatedCompatibility = compatibility?.map((compatibility) => {
+    // eslint-disable-next-line no-unused-vars
+    const { _key, ...rest } = compatibility
+
+    return rest
+  })
+
+  const sanitizedChanges = { ...restOfChanges, compatibility: updatedCompatibility }
+  const pluginChanges = convertCmsChangesToRepoPlugin(sanitizedChanges)
 
   let pluginToUpdate = plugins.find((plugin) => plugin.package === pluginChanges.package)
 

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -204,9 +204,9 @@ const stripNullifiedFields = (plugin) => {
  */
 export const updatePlugins = (changes, plugins) => {
   const { compatibility, ...restOfChanges } = changes
-  const updatedCompatibility = compatibility?.map((compatibility) => {
+  const updatedCompatibility = compatibility?.map((compatibilityItem) => {
     // eslint-disable-next-line no-unused-vars
-    const { _key, ...rest } = compatibility
+    const { _key, ...rest } = compatibilityItem
 
     return rest
   })

--- a/test/bin/utils.js
+++ b/test/bin/utils.js
@@ -177,13 +177,23 @@ test('should return no plugin diffs for Sanity if there are no changes', (t) => 
 
 test('should update a plugin', (t) => {
   const changes = {
-    compatibility: null,
     description: 'Require visual changes on production to be manually approved before going live!',
     packageName: 'netlify-plugin-visual-diff',
     repoUrl: 'https://github.com/applitools/netlify-plugin-visual-diff',
     status: 'active',
     title: 'Visual diff (Applitools)',
     version: '5.0.0',
+    compatibility: [
+      {
+        _key: 'dfsfg3443sdfgdfgd',
+        version: '3.0.0',
+      },
+      {
+        _key: 'dfsfg3443sdfgdfgd',
+        version: '1.3.0',
+        nodeVersion: '<12.0.0',
+      },
+    ],
   }
 
   const plugins = [
@@ -231,6 +241,15 @@ test('should update a plugin', (t) => {
       package: 'netlify-plugin-visual-diff',
       repo: 'https://github.com/applitools/netlify-plugin-visual-diff',
       version: '5.0.0',
+      compatibility: [
+        {
+          version: '3.0.0',
+        },
+        {
+          version: '1.3.0',
+          nodeVersion: '<12.0.0',
+        },
+      ],
     },
     {
       author: 'pizzafox',

--- a/types/plugins.d.ts
+++ b/types/plugins.d.ts
@@ -5,7 +5,7 @@ export interface SanityBuildPluginEntity {
       name: string | null
     },
   ]
-  compatibility: null
+  compatibility?: Compatibility[]
   description: string
   packageName: string
   repoUrl: string


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [ ] Updating a plugin
- [x] Automation

Fixes an issue with the CMS to repo sync that caused builds to fail. Now the `_key` field of the compatibitlity array items is no longer included in the synched data.

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
