### PR TITLE
feat: support env vars in plugin definitions

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -161,11 +161,26 @@ export const getPluginDiffsForSanity = (pluginLookup, plugins) => {
  * @returns {BuildPluginEntity}
  */
 const convertCmsChangesToRepoPlugin = (plugin) => {
-  const { compatibility, description, packageName, status: rawStatus, repoUrl: repo, title: name, version } = plugin
+  const {
+    compatibility,
+    description,
+    packageName,
+    status: rawStatus,
+    repoUrl: repo,
+    title: name,
+    version,
+    metadata,
+  } = plugin
   /**
    * @type {BuildPluginEntity['status']}
    */
   const status = rawStatus === 'deactivated' ? rawStatus.toUpperCase() : undefined
+
+  const variables =
+    metadata?.variables.map(({ name: varName, description: varDescription }) => ({
+      name: varName,
+      description: varDescription,
+    })) || []
 
   return {
     name,
@@ -175,6 +190,7 @@ const convertCmsChangesToRepoPlugin = (plugin) => {
     version,
     status,
     compatibility,
+    variables,
   }
 }
 
@@ -189,6 +205,11 @@ const stripNullifiedFields = (plugin) => {
   if (!plugin.compatibility) {
     // eslint-disable-next-line no-param-reassign
     delete plugin.compatibility
+  }
+
+  if (!plugin.variables || plugin.variables.length === 0) {
+    // eslint-disable-next-line no-param-reassign
+    delete plugin.variables
   }
 
   return plugin

--- a/test/bin/utils.js
+++ b/test/bin/utils.js
@@ -419,6 +419,89 @@ test('should update compatibility', (t) => {
   t.deepEqual(actual, expected)
 })
 
+test('should update metadata variables', (t) => {
+  const changes = {
+    metadata: {
+      variables: [
+        {
+          name: 'FOO',
+          description: 'A foo variable',
+        },
+      ],
+    },
+    description: 'Require visual changes on production to be manually approved before going live!',
+    netlifyVerified: false,
+    packageName: 'netlify-plugin-visual-diff',
+    repoUrl: 'https://github.com/applitools/netlify-plugin-visual-diff',
+    status: 'active',
+    title: 'Visual diff (Applitools)',
+    version: '5.0.0',
+  }
+  const plugins = [
+    {
+      author: 'applitools',
+      description: 'Require visual changes on production to be manually approved before going live!',
+      name: 'Visual diff (Applitools)',
+      package: 'netlify-plugin-visual-diff',
+      repo: 'https://github.com/applitools/netlify-plugin-visual-diff',
+      version: '5.0.0',
+    },
+    {
+      author: 'pizzafox',
+      description: 'This plugin is deprecated. The functionality is now built in',
+      name: 'Next.js cache',
+      package: 'netlify-plugin-cache-nextjs',
+      repo: 'https://github.com/pizzafox/netlify-cache-nextjs',
+      version: '1.4.0',
+      status: 'DEACTIVATED',
+    },
+    {
+      author: 'netlify-labs',
+      description: 'Automatically generate a sitemap for your site on PostBuild in Netlify',
+      name: 'Sitemap',
+      package: '@netlify/plugin-sitemap',
+      repo: 'https://github.com/netlify-labs/netlify-plugin-sitemap',
+      version: '0.8.1',
+    },
+  ]
+  const actual = updatePlugins(changes, plugins)
+  const expected = [
+    {
+      author: 'applitools',
+      variables: [
+        {
+          name: 'FOO',
+          description: 'A foo variable',
+        },
+      ],
+      description: 'Require visual changes on production to be manually approved before going live!',
+      name: 'Visual diff (Applitools)',
+      package: 'netlify-plugin-visual-diff',
+      repo: 'https://github.com/applitools/netlify-plugin-visual-diff',
+      version: '5.0.0',
+    },
+    {
+      author: 'pizzafox',
+      description: 'This plugin is deprecated. The functionality is now built in',
+      name: 'Next.js cache',
+      package: 'netlify-plugin-cache-nextjs',
+      repo: 'https://github.com/pizzafox/netlify-cache-nextjs',
+      version: '1.4.0',
+      status: 'DEACTIVATED',
+    },
+    {
+      author: 'netlify-labs',
+      description: 'Automatically generate a sitemap for your site on PostBuild in Netlify',
+      name: 'Sitemap',
+      package: '@netlify/plugin-sitemap',
+      repo: 'https://github.com/netlify-labs/netlify-plugin-sitemap',
+      version: '0.8.1',
+    },
+  ]
+
+  t.deepEqual(actual, expected)
+})
+
 test('should mark status as DEACTIVATED', (t) => {
   const changes = {
     compatibility: null,


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [ ] Updating a plugin

Adding functionality to the Sanity -> Github plugin sync, decorating plugins with any defined environment variables

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
