### PR TITLE
fix: use generated token for sanity to github plugin sync

### DIFF
--- a/.github/workflows/sync-cms-to-repo.yml
+++ b/.github/workflows/sync-cms-to-repo.yml
@@ -3,8 +3,6 @@ on:
   repository_dispatch:
     # sync_cms_to_repo is a bespoke type created for use with the CMS Webhook
     types: [sync_cms_to_repo]
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   sync-to-repo:
     runs-on: ubuntu-latest
@@ -19,13 +17,15 @@ jobs:
           check-latest: true
       - name: Install dependencies
         run: npm install
-      - name: Setup git config
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Generate GitHub token
+        uses: navikt/github-app-token-generator@v1.1.1
+        id: get-token
+        with:
+          private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
+          app-id: ${{ secrets.TOKENS_APP_ID }}
       - name: Sync CMS to repo
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           CMS_CHANGES: ${{ toJson(github.event.client_payload) }}
 
         run: bin/sync_cms_to_repo.sh


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

- Use an auto-generated token to allow actions to run on PRs generated from Sanity changes

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
