### PR TITLE
fix: add variables to build step test

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -13,8 +13,8 @@ const { manifest } = pacote
 const { valid: validVersion, validRange, lt: ltVersion, major, minor, patch, minVersion } = semver
 
 const STRING_ATTRIBUTES = ['author', 'description', 'name', 'package', 'repo', 'status', 'version']
-const OPTIONAL_ATTRIBUTES = new Set(['status', 'compatibility'])
-const ATTRIBUTES = new Set([...STRING_ATTRIBUTES, 'compatibility'])
+const OPTIONAL_ATTRIBUTES = new Set(['status', 'compatibility', 'variables'])
+const ATTRIBUTES = new Set([...STRING_ATTRIBUTES, 'compatibility', 'variables'])
 const ENUMS = {
   status: ['DEACTIVATED', undefined],
 }
@@ -56,9 +56,9 @@ const getMajorVersion = function (version) {
 }
 
 /* eslint-disable max-nested-callbacks */
-// eslint-disable-next-line max-lines-per-function
+// eslint-disable-next-line max-lines-per-function, max-statements
 pluginsList.forEach((plugin) => {
-  const { package: packageName, repo, version, name, compatibility } = plugin
+  const { package: packageName, repo, version, name, compatibility, variables } = plugin
 
   Object.entries(plugin).forEach(([attribute, value]) => {
     test(`Plugin attribute "${attribute}" should have a proper shape: ${packageName}`, (t) => {
@@ -95,6 +95,17 @@ pluginsList.forEach((plugin) => {
   test(`Plugin name should start with an uppercase letter: ${packageName}`, (t) => {
     t.true(typeof name === 'string' && name === upperCaseFirst(name))
   })
+
+  if (variables) {
+    test('Plugin variables should be an array of objects with name and description', (t) => {
+      t.true(Array.isArray(variables))
+      variables.forEach((variable) => {
+        t.true(isPlainObj(variable))
+        t.true(typeof variable.name === 'string')
+        t.true(typeof variable.description === 'string')
+      })
+    })
+  }
 
   if (compatibility === undefined) {
     return


### PR DESCRIPTION
Update tests run in `build` to correctly handle variables introduced from Sanity sync