### PR TITLE
chore: remove frameworks team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*                 @netlify/ecosystem-pod-frameworks @netlify/ecosystem-pod-integrations
+*                 @netlify/ecosystem-pod-integrations
 docs/             @netlify/department-docs


### PR DESCRIPTION
Removing `@netlify/ecosystem-pod-frameworks` as a codeowner
