### PR TITLE
feat: add docs url to plugin model

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -170,6 +170,7 @@ const convertCmsChangesToRepoPlugin = (plugin) => {
     title: name,
     version,
     metadata,
+    docsUrl: docs,
   } = plugin
   /**
    * @type {BuildPluginEntity['status']}
@@ -191,6 +192,7 @@ const convertCmsChangesToRepoPlugin = (plugin) => {
     status,
     compatibility,
     variables,
+    docs,
   }
 }
 
@@ -210,6 +212,11 @@ const stripNullifiedFields = (plugin) => {
   if (!plugin.variables || plugin.variables.length === 0) {
     // eslint-disable-next-line no-param-reassign
     delete plugin.variables
+  }
+
+  if (!plugin.docs) {
+    // eslint-disable-next-line no-param-reassign
+    delete plugin.docs
   }
 
   return plugin

--- a/test/main.js
+++ b/test/main.js
@@ -12,8 +12,8 @@ import { pluginsList, pluginsUrl } from '../index.js'
 const { manifest } = pacote
 const { valid: validVersion, validRange, lt: ltVersion, major, minor, patch, minVersion } = semver
 
-const STRING_ATTRIBUTES = ['author', 'description', 'name', 'package', 'repo', 'status', 'version']
-const OPTIONAL_ATTRIBUTES = new Set(['status', 'compatibility', 'variables', 'workflow'])
+const STRING_ATTRIBUTES = ['author', 'description', 'name', 'package', 'repo', 'status', 'version', 'docs']
+const OPTIONAL_ATTRIBUTES = new Set(['status', 'compatibility', 'variables', 'workflow', 'docs'])
 const ATTRIBUTES = new Set([...STRING_ATTRIBUTES, 'compatibility', 'variables', 'workflow'])
 const ENUMS = {
   status: ['DEACTIVATED', undefined],


### PR DESCRIPTION
Include plugin docs from Sanity, to enable a link to the documentation in the plugin installation flow.