### PR TITLE
feat: latest version of gatsby plugin now requires v3 and up

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -648,7 +648,7 @@
       {
         "version": "1.0.3",
         "siteDependencies": {
-          "gatsby": "<4.0.0"
+          "gatsby": "<3.0.0"
         }
       }
     ]


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [X] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
