### PR TITLE
fix: Revert Gatsby featureFlag

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -639,7 +639,7 @@
     "compatibility": [
       {
         "version": "3.5.2",
-        "featureFlag": "build_plugins_use_prerelease",
+        "featureFlag": "gatsby_plugin_prerelease",
         "siteDependencies": {
           "gatsby": ">=2.0.0"
         }


### PR DESCRIPTION
This reverts commit 47304e56218336cb4cfc7289f7a5bd08e12758a2.

Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [X] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
