### PR TITLE
feat: remove prerelease feature flag, bump main to 3.6.0 for gatsby

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -639,14 +639,10 @@
     "name": "Essential Gatsby",
     "package": "@netlify/plugin-gatsby",
     "repo": "https://github.com/netlify/netlify-plugin-gatsby",
-    "version": "3.5.2",
+    "version": "3.6.0",
     "compatibility": [
       {
         "version": "3.6.0",
-        "featureFlag": "gatsby_plugin_prerelease"
-      },
-      {
-        "version": "3.5.2",
         "migrationGuide": "https://ntl.fyi/gatsby-plugin-migration"
       },
       {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

3.6.0 was being tested in staged rollout through previous week and now it's time to promote it

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
