### PR TITLE
Deactivate Image Optim plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -446,7 +446,8 @@
     "name": "Image Optim",
     "package": "netlify-plugin-image-optim",
     "repo": "https://github.com/chrisdwheatley/netlify-plugin-image-optim",
-    "version": "0.4.0"
+    "version": "0.4.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "borisschapira",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin - marking as deactivated because I discovered that the [source repo](https://github.com/chrisdwheatley/netlify-plugin-image-optim) has been archived. 

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] (N/A) ~Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.~

**Test plan**
N/A