### PR TITLE
feat: add Next.js runtime 4.39.0 behind a feature flag

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -612,6 +612,10 @@
     "version": "4.38.1",
     "compatibility": [
       {
+        "version": "4.39.0",
+        "featureFlag": "build_plugins_use_prerelease"
+      },
+      {
         "version": "4.38.1",
         "migrationGuide": "https://ntl.fyi/next-plugin-migration"
       },


### PR DESCRIPTION
Enabling 4.39 behind feature flag (next-runtime)