### PR TITLE
feat: set next.js runtime 4.39.1 stable and 4.39.2 in prerelease

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -609,14 +609,14 @@
     "name": "Next.js Runtime",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/next-runtime",
-    "version": "4.39.0",
+    "version": "4.39.1",
     "compatibility": [
       {
-        "version": "4.39.1",
+        "version": "4.39.2",
         "featureFlag": "build_plugins_use_prerelease"
       },
       {
-        "version": "4.39.0",
+        "version": "4.39.1",
         "migrationGuide": "https://ntl.fyi/next-plugin-migration"
       },
       {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

Set @netlify/plugin-nextjs 4.39.1 as stable and 4.39.2 in prerelease