### PR TITLE
Update Cloudinary version

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -888,7 +888,7 @@
     "name": "Cloudinary",
     "package": "netlify-plugin-cloudinary",
     "repo": "https://github.com/cloudinary-community/netlify-plugin-cloudinary",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "variables": [
       {
         "name": "CLOUDINARY_CLOUD_NAME",

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -887,7 +887,7 @@
     "description": "Automatically optimize your Netlify site images and deliver them in modern formats with Cloudinary.",
     "name": "Cloudinary",
     "package": "netlify-plugin-cloudinary",
-    "repo": "https://github.com/colbyfayock/netlify-plugin-cloudinary",
+    "repo": "https://github.com/cloudinary-community/netlify-plugin-cloudinary",
     "version": "1.0.3",
     "variables": [
       {

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -888,7 +888,7 @@
     "name": "Cloudinary",
     "package": "netlify-plugin-cloudinary",
     "repo": "https://github.com/cloudinary-community/netlify-plugin-cloudinary",
-    "version": "1.0.3",
+    "version": "1.10.1",
     "variables": [
       {
         "name": "CLOUDINARY_CLOUD_NAME",


### PR DESCRIPTION
**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.


Updates Cloudinary  version to 1.10.2 to address a bug that uses the wrong Netlify URLs for deployed images.

The URL used now reflects:
```
  let host = process.env.URL;

  if ( process.env.CONTEXT === 'branch-deploy' || process.env.CONTEXT === 'deploy-preview' ) {
    host = process.env.DEPLOY_PRIME_URL || ''
  }
```

This unfortunately hasn't been tested in a prod-like environment beyond local development with `--context production` and using the Netlify Cloudinary project which builds with the latest plugin version by using the locally referenced version as I can't pin, but sounds like that will change with the new SDK for testing purposes.