### PR TITLE
feat: set next.js runtime 4.40.1 as stable version

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -609,14 +609,10 @@
     "name": "Next.js Runtime",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/next-runtime",
-    "version": "4.39.4",
+    "version": "4.40.1",
     "compatibility": [
       {
         "version": "4.40.1",
-        "featureFlag": "build_plugins_use_prerelease"
-      },
-      {
-        "version": "4.39.4",
         "migrationGuide": "https://ntl.fyi/next-plugin-migration"
       },
       {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [ ] Updating a plugin

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
