### PR TITLE
feat: bump @netlify/plugin-nextjs to 5.5.0

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -618,7 +618,7 @@
     "version": "4.41.3",
     "compatibility": [
       {
-        "version": "5.4.0",
+        "version": "5.5.0",
         "featureFlag": "project_ceruledge_ui",
         "overridePinnedVersion": ">=4.0.0",
         "nodeVersion": ">=18.0.0",


### PR DESCRIPTION
See https://github.com/netlify/next-runtime/releases/tag/v5.5.0.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
