### PR TITLE
feat: add @netlify/plugin-nextjs@5.7.0-ipx.0

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -618,6 +618,15 @@
     "version": "4.41.3",
     "compatibility": [
       {
+        "version": "5.7.0-ipx.0",
+        "featureFlag": "plugins-aerodactyl",
+        "overridePinnedVersion": ">=4.0.0",
+        "nodeVersion": ">=18.0.0",
+        "siteDependencies": {
+          "next": ">=13.5.0"
+        }
+      },
+      {
         "version": "5.6.0",
         "featureFlag": "project_ceruledge_ui",
         "overridePinnedVersion": ">=4.0.0",


### PR DESCRIPTION
Add a special IPX build of the next-runtime, behind a feature flag.

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**

@pieh tested it