### PR TITLE
fix: bump next-runtime to 5.11.1

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -627,7 +627,7 @@
         }
       },
       {
-        "version": "5.11.0",
+        "version": "5.11.1",
         "featureFlag": "project_ceruledge_ui",
         "overridePinnedVersion": ">=4.0.0",
         "nodeVersion": ">=18.0.0",


### PR DESCRIPTION
https://github.com/opennextjs/opennextjs-netlify/pull/2904