### PR TITLE
fix: build plugin audit, remove plugins made for services that no longer exist

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -191,7 +191,8 @@
     "name": "Snaplet",
     "package": "@snaplet/netlify-preview-database-plugin",
     "repo": "https://github.com/snaplet/netlify-preview-database-plugin",
-    "version": "2.0.0"
+    "version": "2.0.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "sw-yx",

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -13,7 +13,8 @@
     "name": "Nimbella",
     "package": "netlify-plugin-nimbella",
     "repo": "https://github.com/nimbella/netlify-plugin-nimbella",
-    "version": "2.1.0"
+    "version": "2.1.0",
+    "status": "DEACTIVATED"
   },
   {
     "author": "chrism2671",


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

Both of these services no longer exist, removing from the site

**Have you completed the following?**

- [ ] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [ ] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [ ] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
