### PR TITLE
Add community project example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 ## Code of Conduct
 
 This project and everyone participating in it is governed by a [code of conduct](./docs/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to conduct@netlify.com.
+## Community Projects Using Netlify
+
+- [7 Brew Menu Guide](https://7brewmenuguide.com) – A static site example showcasing fast content delivery using Netlify hosting and build automation.


### PR DESCRIPTION
This PR introduces a new section called "Community Projects Using Netlify" in the README file.

It features [7 Brew Menu Guide](https://7brewmenuguide.com), a publicly accessible static website hosted on Netlify, as a real-world deployment example.

The goal is to highlight how Netlify is used in public JAMstack projects and to inspire similar deployments by others.

Feedback welcome.
