### PR TITLE
fix: bump next-runtime to 5.15.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -25,3 +27,5 @@ jobs:
         run: npm run format:ci
       - name: Tests
         run: npm run test:ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -615,7 +615,7 @@
     "name": "Next.js ",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/next-runtime",
-    "version": "5.15.8",
+    "version": "5.15.9",
     "compatibility": [
       {
         "version": "5.7.0-ipx.0",
@@ -627,7 +627,7 @@
         }
       },
       {
-        "version": "5.15.8",
+        "version": "5.15.9",
         "overridePinnedVersion": ">=4.0.0",
         "nodeVersion": ">=18.0.0",
         "siteDependencies": {

--- a/test/main.js
+++ b/test/main.js
@@ -9,6 +9,30 @@ import { upperCaseFirst } from 'upper-case-first'
 
 import { pluginsList, pluginsUrl } from '../index.js'
 
+const sleep = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+const BACKOFF_BASE = 5000
+const ONE_SECOND_IN_MS = 1000
+
+const fetchWithRetry = async (url, { retries = 3, backoff = BACKOFF_BASE } = {}) => {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await got(url)
+    } catch (error) {
+      // eslint-disable-next-line max-depth
+      if (error.response?.statusCode === 429 && attempt < retries) {
+        const retryAfter = Number(error.response.headers['retry-after']) * ONE_SECOND_IN_MS || backoff * (attempt + 1)
+        await sleep(retryAfter)
+        continue
+      }
+      throw error
+    }
+  }
+}
+
 const { manifest } = pacote
 const { valid: validVersion, validRange, lt: ltVersion, major, minor, patch, minVersion } = semver
 
@@ -87,7 +111,7 @@ pluginsList.forEach((plugin) => {
     })
 
     test(`Plugin repository URL should be valid: ${packageName}`, async (t) => {
-      await t.notThrowsAsync(got(repo))
+      await t.notThrowsAsync(fetchWithRetry(repo))
     })
   }
 
@@ -163,7 +187,7 @@ pluginsList.forEach((plugin) => {
 
       t.is(typeof migrationGuide, 'string')
       t.notThrows(() => new URL(migrationGuide))
-      await t.notThrowsAsync(got(migrationGuide))
+      await t.notThrowsAsync(fetchWithRetry(migrationGuide))
     })
 
     test(`Plugin compatibility[${index}].featureFlag is valid: ${packageName}`, (t) => {

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,6 @@
 /* eslint-disable max-lines */
+import process from 'node:process'
+
 import test from 'ava'
 import got from 'got'
 import isPlainObj from 'is-plain-obj'
@@ -18,9 +20,13 @@ const BACKOFF_BASE = 5000
 const ONE_SECOND_IN_MS = 1000
 
 const fetchWithRetry = async (url, { retries = 3, backoff = BACKOFF_BASE } = {}) => {
+  const headers = {}
+  if (process.env.GITHUB_TOKEN && url.includes('github.com')) {
+    headers.Authorization = `token ${process.env.GITHUB_TOKEN}`
+  }
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      return await got(url)
+      return await got(url, { headers })
     } catch (error) {
       // eslint-disable-next-line max-depth
       if (error.response?.statusCode === 429 && attempt < retries) {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
