### PR TITLE
Add axle-netlify-plugin (accessibility compliance CI)

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -103,7 +103,7 @@
   },
   {
     "author": "edm00se",
-    "description": "Persist the Gridsome cache between Netlify builds for huge speed improvements! ⚡️",
+    "description": "Persist the Gridsome cache between Netlify builds for huge speed improvements! \u26a1\ufe0f",
     "name": "Gridsome cache",
     "package": "netlify-plugin-gridsome-cache",
     "repo": "https://github.com/edm00se/netlify-plugin-gridsome-cache",
@@ -291,7 +291,7 @@
   },
   {
     "author": "Tom-Bonnike",
-    "description": "Improve your site’s performance by inlining some of your assets/sources, reducing the number of HTTP requests your users need to make.",
+    "description": "Improve your site\u2019s performance by inlining some of your assets/sources, reducing the number of HTTP requests your users need to make.",
     "name": "Inline source",
     "package": "netlify-plugin-inline-source",
     "repo": "https://github.com/Tom-Bonnike/netlify-plugin-inline-source",
@@ -317,7 +317,7 @@
   },
   {
     "author": "tzmanics",
-    "description": "🔌A Netlify Build Plugin to check your project for misspellings of important, brand-related words ☑️.",
+    "description": "\ud83d\udd0cA Netlify Build Plugin to check your project for misspellings of important, brand-related words \u2611\ufe0f.",
     "name": "Brand guardian",
     "package": "netlify-plugin-brand-guardian",
     "repo": "https://github.com/tzmanics/netlify-plugin-brand-guardian",
@@ -326,7 +326,7 @@
   },
   {
     "author": "tzmanics",
-    "description": "🔌A Netlify Build Plugin to show you how to use Netlify Build Plugins",
+    "description": "\ud83d\udd0cA Netlify Build Plugin to show you how to use Netlify Build Plugins",
     "name": "All events",
     "package": "netlify-plugin-to-all-events",
     "repo": "https://github.com/tzmanics/netlify-plugin-to-all-events",
@@ -597,7 +597,7 @@
     "variables": [
       {
         "name": " ALGOLIA_BASE_URL",
-        "description": "URL to target, should be “https://crawler.algolia.com/”"
+        "description": "URL to target, should be \u201chttps://crawler.algolia.com/\u201d"
       },
       {
         "name": "ALGOLIA_API_KEY",
@@ -723,7 +723,7 @@
   },
   {
     "author": "flaurida",
-    "description": "Run QA Wolf end-to-end tests on Netlify deployments 🐺",
+    "description": "Run QA Wolf end-to-end tests on Netlify deployments \ud83d\udc3a",
     "name": "QA Wolf",
     "package": "netlify-plugin-qawolf",
     "repo": "https://github.com/qawolf/netlify-plugin-qawolf",
@@ -981,7 +981,7 @@
   },
   {
     "author": "Inngest",
-    "description": "Automatically deploy Inngest functions to Netlify’s platform. ",
+    "description": "Automatically deploy Inngest functions to Netlify\u2019s platform. ",
     "name": "Inngest",
     "package": "netlify-plugin-inngest",
     "repo": "https://github.com/inngest/netlify-plugin-inngest",
@@ -1042,5 +1042,19 @@
     "repo": "https://github.com/jclusso/strapi-plugin-netlify-deployments#readme",
     "version": "2.0.1",
     "docs": "https://market.strapi.io/plugins/strapi-plugin-netlify-deployments"
+  },
+  {
+    "author": "asafamos",
+    "description": "Scan every deploy preview for WCAG 2.1/2.2 AA accessibility violations with axe-core 4.11. Optional Claude-generated code fixes. Built for EAA 2025, ADA, Israeli \u05ea\u05e7\u05e0\u05d4 35.",
+    "name": "Axle Accessibility",
+    "package": "axle-netlify-plugin",
+    "repo": "https://github.com/asafamos/axle",
+    "version": "1.0.1",
+    "variables": [
+      {
+        "name": "ANTHROPIC_API_KEY",
+        "description": "Anthropic API key for Claude-generated fix diffs (only required when inputs.withAiFixes is true)."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds [axle-netlify-plugin](https://www.npmjs.com/package/axle-netlify-plugin) to `site/plugins.json`.

## What it does

Scans every Netlify deploy preview for WCAG 2.1 / 2.2 AA accessibility violations using axe-core 4.11. When enabled, Claude Sonnet generates source-code fix diffs per violation for inclusion in the build log. Fails the build when violations meet or exceed a configurable severity threshold — so accessibility regressions can't ship.

## Why this plugin

- Purpose-built for the EAA 2025 / ADA / Israeli תקנה 35 regulatory wave.
- Same engine as our [GitHub Action](https://github.com/marketplace/actions/axle-accessibility-compliance-ci), [npm CLI](https://www.npmjs.com/package/axle-cli), [Cloudflare Pages plugin](https://www.npmjs.com/package/axle-cloudflare-plugin), and [Vercel plugin](https://www.npmjs.com/package/axle-vercel-plugin) — one consistent scanner across the whole deploy ecosystem.
- No overlay widget is injected into the deployed site. The plugin runs at build time against the deploy-prime URL and never touches end-user pages.
- Zero-config: works with defaults out of the box against `DEPLOY_PRIME_URL`; every input has a sensible default.

## Checklist (per plugin review guidelines)

- [x] Open source (MIT) — [source](https://github.com/asafamos/axle/tree/main/packages/axle-netlify)
- [x] Works with no inputs configured (uses `DEPLOY_PRIME_URL`)
- [x] `manifest.yml` present, `name` matches the npm package name
- [x] package.json has `repository`, `bugs`, `homepage`
- [x] Keywords include `netlify` and `netlify-plugin`
- [x] Package name starts with a recognizable identifier (`axle-netlify-plugin`)
- [x] Uses `onPostBuild`, returns `failBuild()` appropriately
- [x] No post-deploy logic in `onPostBuild` (all scanning happens in-phase)
- [x] Inputs all have a `name` and a `description`

## Inputs

- `failOn` — severity threshold (`critical` / `serious` / `moderate` / `minor` / `none`). Default: `serious`.
- `withAiFixes` — generate AI fix suggestions (requires `ANTHROPIC_API_KEY` env var). Default: `false`.
- `maxAiFixes` — cost guard on AI calls per build. Default: `10`.
- `url` — override the scan URL. Defaults to `DEPLOY_PRIME_URL`.

## Environment variables (optional)

- `ANTHROPIC_API_KEY` — only required when `withAiFixes` is true. Claude generates the fix diffs.

Happy to adjust description length, entry placement, or any metadata if the current format needs changes.