### PR TITLE
fix: bump next-runtime to 5.15.12

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -615,7 +615,7 @@
     "name": "Next.js ",
     "package": "@netlify/plugin-nextjs",
     "repo": "https://github.com/netlify/next-runtime",
-    "version": "5.15.11",
+    "version": "5.15.12",
     "compatibility": [
       {
         "version": "5.7.0-ipx.0",
@@ -627,7 +627,7 @@
         }
       },
       {
-        "version": "5.15.11",
+        "version": "5.15.12",
         "overridePinnedVersion": ">=4.0.0",
         "nodeVersion": ">=18.0.0",
         "siteDependencies": {


### PR DESCRIPTION
Thanks for contributing the Netlify plugins directory!

**Are you adding a plugin or updating one?**

- [ ] Adding a plugin
- [x] Updating a plugin

**Have you completed the following?**

- [x] Read and followed the [plugin author guidelines](https://github.com/netlify/plugins/blob/main/docs/guidelines.md).
- [x] Included all [required fields](https://github.com/netlify/plugins/blob/main/docs/CONTRIBUTING.md#required-fields) in your entry.
- [x] Tested the plugin [locally](https://docs.netlify.com/cli/get-started/#run-builds-locally) and [on Netlify](https://docs.netlify.com/configure-builds/build-plugins/#install-a-plugin), using the plugin version stated in your entry.

**Test plan**
Please add a link to a successful public deploy log using the stated version of the plugin. Include any other context reviewers might need for testing.
