### PR TITLE
fix: version gate for next-runtime

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -652,7 +652,7 @@
         "siteDependencies": {
           "next": "<10.0.6"
         }
-      },
+      }
     ]
   },
   {

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -636,12 +636,9 @@
       },
       {
         "version": "4.41.6",
-        "migrationGuide": "https://ntl.fyi/next-plugin-migration"
-      },
-      {
-        "version": "3.9.2",
+        "migrationGuide": "https://ntl.fyi/next-plugin-migration",
         "siteDependencies": {
-          "next": "<10.0.9"
+          "next": "<13.5.0"
         }
       },
       {
@@ -649,7 +646,13 @@
         "siteDependencies": {
           "next": "<10.0.6"
         }
-      }
+      },
+      {
+        "version": "3.9.2",
+        "siteDependencies": {
+          "next": "<10.0.9"
+        }
+      },
     ]
   },
   {

--- a/site/plugins.json
+++ b/site/plugins.json
@@ -614,7 +614,7 @@
     "description": "Build and deploy Next.js applications with server-side rendering. No extra configuration required.",
     "name": "Next.js ",
     "package": "@netlify/plugin-nextjs",
-    "repo": "https://github.com/netlify/next-runtime",
+    "repo": "https://github.com/opennextjs/opennextjs-netlify",
     "version": "5.15.13",
     "compatibility": [
       {
@@ -642,15 +642,15 @@
         }
       },
       {
-        "version": "1.1.5",
+        "version": "3.9.2",
         "siteDependencies": {
-          "next": "<10.0.6"
+          "next": ">=10.0.6 <10.0.9"
         }
       },
       {
-        "version": "3.9.2",
+        "version": "1.1.5",
         "siteDependencies": {
-          "next": "<10.0.9"
+          "next": "<10.0.6"
         }
       },
     ]


### PR DESCRIPTION
Fixes https://linear.app/netlify/issue/FRB-2325/

In the current array, Next.js Runtime v4 was the ultimate fallback as it had no version constraints. For new Next.js sites where we fail to detect the Next.js version by any chance, we end up falling back to v4 of Next.js Runtime due to this. With the new version gate, we should now be able to get the latest version as the fallback as new sites would mostly use a recent version of Next.js.

This would now create a problem for these situations:

- An existing site (built on Next 13.5–13.9 years ago) that's only now adding `@netlify/plugin-nextjs` to its config for the first time, or migrating onto Netlify.
- A site that's had the plugin config removed/changed and is re-resolving from scratch.
- Any site whose pin record didn't get set for some other reason (failed prior runs, manual config changes, etc.).

That is, sites using Next.js 13.5-13.9 and Node.js < 18 will now be forced to use Next.js Runtime v5 which doesn't support Node < 18. I do not think this would be a real use-case though.

Also fixed the ordering as `<10.0.6` is also `<10.0.9`, so v1 would never match unless it's pinned. This should not be relevant anymore though.